### PR TITLE
Add threading configuration for dramatiq worker

### DIFF
--- a/docker/web/dramatiq/worker/run.sh
+++ b/docker/web/dramatiq/worker/run.sh
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
-dramatiq app.workers.tasks & # dramatiq async actors
+TASK_CONCURRENCY=${TASK_CONCURRENCY:-100}
+
+echo "==> $(date +%H:%M:%S) ==> Running Dramatiq worker with concurrency $TASK_CONCURRENCY <=="
+dramatiq app.workers.tasks --processes 1 --threads $TASK_CONCURRENCY & # dramatiq async actors
 periodiq -v app.workers.tasks & # cron dramatiq async actors
 
 wait


### PR DESCRIPTION
Enable threading for dramatiq. 
Set 1 process by default and not configurable value, because `dramatiq` do a fork and duplicates the process memory, this could cause issues for singleton instances. 