### PR TITLE
Remove unbind and delete queue in queue disconnect method

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,3 +1,4 @@
 REDIS_URL=redis://redis:6379/0
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/postgres
 RABBITMQ_AMQP_URL=amqp://guest:guest@rabbitmq:5672/
+LOG_LEVEL=INFO

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
 REDIS_URL=redis://redis:6379/0
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/postgres
 RABBITMQ_AMQP_URL=amqp://guest:guest@rabbitmq:5672/
+LOG_LEVEL=INFO

--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ REDIS_URL=redis://localhost:6379/0
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/postgres
 DATABASE_POOL_CLASS=NullPool
 RABBITMQ_AMQP_URL=amqp://guest:guest@localhost:5672/
+LOG_LEVEL=INFO

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@
 Base settings file for FastApi application.
 """
 
+import logging
 import os
 import secrets
 
@@ -16,6 +17,7 @@ class Settings(BaseSettings):
         case_sensitive=True,
     )
     TEST: bool = False
+    LOG_LEVEL: str = "INFO"
     REDIS_URL: str = "redis://"
     DATABASE_URL: str = "psql://postgres:"
     DATABASE_POOL_CLASS: str = "AsyncAdaptedQueuePool"
@@ -38,3 +40,5 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+logging.basicConfig(level=logging.getLevelName(settings.LOG_LEVEL))


### PR DESCRIPTION
- Related with #54 

- Improved logs
- It's not necessary to remove and unbind the queue every time that the queue provider is disconnected. In that case, when the pod is shutting down, the previous pod removes the connection from the current pod.