### PR TITLE
Fix contract without abi shouldn't be returned

### DIFF
--- a/app/datasources/db/models.py
+++ b/app/datasources/db/models.py
@@ -211,7 +211,7 @@ class Contract(SqlQueryBase, TimeStampedSQLModel, table=True):
     chain_id: int = Field(default=None)
 
     @classmethod
-    def get_contracts_query(
+    def get_contracts_with_abi_query(
         cls, address: bytes, chain_ids: list[int] | None = None
     ) -> SelectBase["Contract"]:
         """
@@ -221,7 +221,7 @@ class Contract(SqlQueryBase, TimeStampedSQLModel, table=True):
         :param chain_ids: list of chain_ids, `None` for all chains
         :return:
         """
-        query = select(cls).where(cls.address == address)
+        query = select(cls).where(cls.address == address, cls.abi_id.isnot(None))  # type: ignore
         if chain_ids:
             query = query.where(col(cls.chain_id).in_(chain_ids)).order_by(
                 col(cls.chain_id).desc()

--- a/app/datasources/db/models.py
+++ b/app/datasources/db/models.py
@@ -215,7 +215,7 @@ class Contract(SqlQueryBase, TimeStampedSQLModel, table=True):
         cls, address: bytes, chain_ids: list[int] | None = None
     ) -> SelectBase["Contract"]:
         """
-        Return a statement to get contracts for the provided address and chain_id
+        Return a statement to get contracts with abi for the provided address and chain_id
 
         :param address:
         :param chain_ids: list of chain_ids, `None` for all chains

--- a/app/routers/contracts.py
+++ b/app/routers/contracts.py
@@ -30,6 +30,17 @@ async def list_contracts(
     chain_ids: Annotated[list[int] | None, Query()] = None,
     session: AsyncSession = Depends(get_database_session),
 ) -> PaginatedResponse[Contract]:
+    """
+    List all contracts for all the chains, or for the provided chains
+    Empty responses indicate that no contract was found
+
+    :param request:
+    :param address:
+    :param pagination_params:
+    :param chain_ids:
+    :param session:
+    :return:
+    """
     if not fast_is_checksum_address(address):
         raise HTTPException(status_code=400, detail="Address is not checksumed")
 

--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -53,7 +53,7 @@ class ContractsPublic(BaseModel):
     display_name: str | None
     chain_id: int
     project: ProjectPublic | None
-    abi: AbiPublic | None
+    abi: AbiPublic
     modified: datetime
 
     class Config:

--- a/app/services/contract.py
+++ b/app/services/contract.py
@@ -33,9 +33,9 @@ class ContractService:
         :return:
         """
         page = await self.pagination.get_page(
-            session, Contract.get_contracts_query(address, chain_ids)
+            session, Contract.get_contracts_with_abi_query(address, chain_ids)
         )
         count = await self.pagination.get_count(
-            session, Contract.get_contracts_query(address, chain_ids)
+            session, Contract.get_contracts_with_abi_query(address, chain_ids)
         )
         return page, count

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -20,16 +20,22 @@ class TestRouterContract(DbAsyncConn):
 
     @database_session
     async def test_view_contracts(self, session: AsyncSession):
+        address_expected = "0x6eEF70Da339a98102a642969B3956DEa71A1096e"
+        address = HexBytes(address_expected)
+        contract = Contract(address=address, name="A Test Contracts", chain_id=1)
+        await contract.create(session)
+        response = self.client.get(
+            f"/api/v1/contracts/{address_expected}",
+        )
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertEqual(response_json["count"], 0)
         source = AbiSource(name="Etherscan", url="https://api.etherscan.io/api")
         await source.create(session)
         abi = Abi(abi_json=mock_abi_json, source_id=source.id)
         await abi.create(session)
-        address_expected = "0x6eEF70Da339a98102a642969B3956DEa71A1096e"
-        address = HexBytes(address_expected)
-        contract = Contract(
-            address=address, name="A Test Contracts", chain_id=1, abi=abi
-        )
-        await contract.create(session)
+        contract.abi_id = abi.id
+        await contract.update(session)
         response = self.client.get(
             f"/api/v1/contracts/{address_expected}",
         )


### PR DESCRIPTION
# Description
Fix contracts without abi shouldn't be returned in the endpoint contracts response
