### PR TITLE
Refactor session

### DIFF
--- a/app/datasources/db/database.py
+++ b/app/datasources/db/database.py
@@ -74,7 +74,7 @@ db_session = async_scoped_session(
 )
 
 
-def session_context_decorator(func):
+def db_session_context(func):
     """
     A decorator that applies the `set_scoped_context` context manager to a function.
     If no session_id is provided, a new UUID will be generated.

--- a/app/datasources/db/session_scope.py
+++ b/app/datasources/db/session_scope.py
@@ -1,0 +1,28 @@
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Generator
+
+_session_context: ContextVar[str] = ContextVar("session_context")
+
+
+@contextmanager
+def set_scoped_session_context(
+    session_id: str | None = None,
+) -> Generator[None, None, None]:
+    """
+    Set the same context session for provided session id or random uuid4
+
+    :param session_id:
+    :return:
+    """
+    _session_id: str = session_id or str(uuid.uuid4())
+    token = _session_context.set(_session_id)
+    try:
+        yield
+    finally:
+        _session_context.reset(token)
+
+
+def get_session_context() -> str:
+    return _session_context.get()

--- a/app/routers/contracts.py
+++ b/app/routers/contracts.py
@@ -4,9 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from hexbytes import HexBytes
 from safe_eth.eth.utils import fast_is_checksum_address
-from sqlmodel.ext.asyncio.session import AsyncSession
 
-from ..datasources.db.database import get_database_session
 from ..datasources.db.models import Contract
 from ..services.contract import ContractService
 from ..services.pagination import (
@@ -28,14 +26,11 @@ async def list_contracts(
     address: str,
     pagination_params: PaginationQueryParams = Depends(),
     chain_ids: Annotated[list[int] | None, Query()] = None,
-    session: AsyncSession = Depends(get_database_session),
 ) -> PaginatedResponse[Contract]:
     if not fast_is_checksum_address(address):
         raise HTTPException(status_code=400, detail="Address is not checksumed")
 
     pagination = GenericPagination(pagination_params.limit, pagination_params.offset)
     contracts_service = ContractService(pagination=pagination)
-    results, count = await contracts_service.get_contracts(
-        session, HexBytes(address), chain_ids
-    )
+    results, count = await contracts_service.get_contracts(HexBytes(address), chain_ids)
     return pagination.serialize(request.url, results, count)

--- a/app/routers/data_decoder.py
+++ b/app/routers/data_decoder.py
@@ -1,6 +1,14 @@
+from typing import cast
+
 from fastapi import APIRouter, HTTPException
 
-from app.routers.models import DataDecodedPublic, DataDecoderInput
+from eth_typing import Address
+
+from app.routers.models import (
+    DataDecodedPublic,
+    DataDecoderInput,
+    ParameterDecodedPublic,
+)
 from app.services.data_decoder import get_data_decoder_service
 
 router = APIRouter(
@@ -17,7 +25,7 @@ async def data_decoder(
     # TODO: Add chainId to get_data_decoded
     data_decoded = await data_decoder_service.get_data_decoded(
         input_data.data,
-        address=input_data.to,
+        address=cast(Address, input_data.to),
         chain_id=input_data.chain_id,
     )
 
@@ -28,12 +36,12 @@ async def data_decoder(
 
     decoding_accuracy = await data_decoder_service.get_decoding_accuracy(
         input_data.data,
-        address=input_data.to,
+        address=cast(Address, input_data.to),
         chain_id=input_data.chain_id,
     )
 
     return DataDecodedPublic(
         method=data_decoded["method"],
-        parameters=data_decoded["parameters"],
+        parameters=cast(list[ParameterDecodedPublic], data_decoded["parameters"]),
         accuracy=decoding_accuracy,
     )

--- a/app/routers/data_decoder.py
+++ b/app/routers/data_decoder.py
@@ -14,6 +14,7 @@ async def data_decoder(
     input_data: DataDecoderInput,
 ) -> DataDecodedPublic:
     data_decoder_service = await get_data_decoder_service()
+    # TODO: Add chainId to get_data_decoded
     data_decoded = await data_decoder_service.get_data_decoded(
         input_data.data,
         address=input_data.to,

--- a/app/services/contract.py
+++ b/app/services/contract.py
@@ -1,7 +1,5 @@
 from typing import Sequence, Tuple
 
-from sqlmodel.ext.asyncio.session import AsyncSession
-
 from app.datasources.db.models import Contract
 from app.services.pagination import GenericPagination
 
@@ -12,17 +10,16 @@ class ContractService:
         self.pagination = pagination
 
     @staticmethod
-    async def get_all(session: AsyncSession) -> Sequence[Contract]:
+    async def get_all() -> Sequence[Contract]:
         """
         Get all contracts
 
-        :param session: passed by the decorator
         :return:
         """
-        return await Contract.get_all(session)
+        return await Contract.get_all()
 
     async def get_contracts(
-        self, session: AsyncSession, address: bytes, chain_ids: list[int] | None
+        self, address: bytes, chain_ids: list[int] | None
     ) -> Tuple[list[Contract], int]:
         """
         Get the contract by address and/or chain_ids
@@ -33,9 +30,9 @@ class ContractService:
         :return:
         """
         page = await self.pagination.get_page(
-            session, Contract.get_contracts_query(address, chain_ids)
+            Contract.get_contracts_query(address, chain_ids)
         )
         count = await self.pagination.get_count(
-            session, Contract.get_contracts_query(address, chain_ids)
+            Contract.get_contracts_query(address, chain_ids)
         )
         return page, count

--- a/app/tests/datasources/db/db_async_conn.py
+++ b/app/tests/datasources/db/db_async_conn.py
@@ -10,13 +10,5 @@ class DbAsyncConn(unittest.IsolatedAsyncioTestCase):
         self.engine = get_engine()
         # Create the database tables
         async with self.engine.begin() as conn:
-            await conn.run_sync(SQLModel.metadata.create_all)
-
-    async def asyncTearDown(self):
-        """
-        Clean data between tests
-
-        :return:
-        """
-        async with self.engine.begin() as conn:
             await conn.run_sync(SQLModel.metadata.drop_all)
+            await conn.run_sync(SQLModel.metadata.create_all)

--- a/app/tests/datasources/db/test_model.py
+++ b/app/tests/datasources/db/test_model.py
@@ -4,7 +4,7 @@ from eth_account import Account
 from hexbytes import HexBytes
 from safe_eth.eth.utils import fast_to_checksum_address
 
-from app.datasources.db.database import session_context_decorator
+from app.datasources.db.database import db_session_context
 from app.datasources.db.models import Abi, AbiSource, Contract, Project
 from app.services.contract_metadata_service import (
     ContractMetadataService,
@@ -18,7 +18,7 @@ from .db_async_conn import DbAsyncConn
 
 class TestModel(DbAsyncConn):
 
-    @session_context_decorator
+    @db_session_context
     async def test_contract(self):
         contract = Contract(
             address=b"a", name="A test contract", chain_id=1, implementation=b"a"
@@ -27,7 +27,7 @@ class TestModel(DbAsyncConn):
         result = await contract.get_all()
         self.assertEqual(result[0], contract)
 
-    @session_context_decorator
+    @db_session_context
     async def test_contract_get_abi_by_contract_address(self):
         abi_json = {"name": "A Test Project with relevance 10"}
         source = AbiSource(name="local", url="")
@@ -52,14 +52,14 @@ class TestModel(DbAsyncConn):
         # Check address not matching
         self.assertIsNone(await contract.get_abi_by_contract_address(b"b", None))
 
-    @session_context_decorator
+    @db_session_context
     async def test_project(self):
         project = Project(description="A Test Project", logo_file="logo.jpg")
         await project.create()
         result = await project.get_all()
         self.assertEqual(result[0], project)
 
-    @session_context_decorator
+    @db_session_context
     async def test_abi(self):
         abi_source = AbiSource(name="A Test Source", url="https://test.com")
         abi_source = await abi_source.create()
@@ -72,7 +72,7 @@ class TestModel(DbAsyncConn):
         result = await abi.get_all()
         self.assertEqual(result[0], abi)
 
-    @session_context_decorator
+    @db_session_context
     async def test_abi_get_abis_sorted_by_relevance(self):
         abi_jsons = [
             {"name": "A Test Project with relevance 100"},
@@ -104,7 +104,7 @@ class TestModel(DbAsyncConn):
         result = await anext(results)
         self.assertEqual(result, abi_jsons[0])
 
-    @session_context_decorator
+    @db_session_context
     async def test_abi_source(self):
         abi_source = AbiSource(name="A Test Source", url="https://test.com")
         await abi_source.create()
@@ -134,7 +134,7 @@ class TestModel(DbAsyncConn):
         self.assertEqual(retrieved_abi_source.url, abi_source.url)
         self.assertFalse(created)
 
-    @session_context_decorator
+    @db_session_context
     async def test_timestamped_model(self):
         contract = Contract(address=b"a", name="A test contract", chain_id=1)
         contract_created_date = contract.created
@@ -155,7 +155,7 @@ class TestModel(DbAsyncConn):
         self.assertNotEqual(result_updated[0].modified, contract_modified_date)
         self.assertTrue(contract_modified_date < result_updated[0].modified)
 
-    @session_context_decorator
+    @db_session_context
     async def test_get_contracts_without_abi(self):
         random_address = HexBytes(Account.create().address)
         abi_json = {"name": "A Test ABI"}
@@ -182,7 +182,7 @@ class TestModel(DbAsyncConn):
         async for contract in Contract.get_contracts_without_abi(10):
             self.fail("Expected no contracts, but found one.")
 
-    @session_context_decorator
+    @db_session_context
     async def test_get_proxy_contracts(self):
         # Test empty case
         async for proxy_contract in Contract.get_proxy_contracts():

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from hexbytes import HexBytes
 
-from ...datasources.db.database import session_context_decorator
+from ...datasources.db.database import db_session_context
 from ...datasources.db.models import Abi, AbiSource, Contract
 from ...main import app
 from ...utils import datetime_to_str
@@ -17,7 +17,7 @@ class TestRouterContract(DbAsyncConn):
     def setUpClass(cls):
         cls.client = TestClient(app)
 
-    @session_context_decorator
+    @db_session_context
     async def test_view_contracts(self):
         source = AbiSource(name="Etherscan", url="https://api.etherscan.io/api")
         await source.create()
@@ -63,7 +63,7 @@ class TestRouterContract(DbAsyncConn):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["chain_id"], 5)
 
-    @session_context_decorator
+    @db_session_context
     async def test_contracts_pagination(self):
         source = AbiSource(name="Etherscan", url="https://api.etherscan.io/api")
         await source.create()

--- a/app/tests/services/test_abis.py
+++ b/app/tests/services/test_abis.py
@@ -1,5 +1,6 @@
 from collections import Counter
 
+from ...datasources.db.database import db_session_context
 from ...datasources.db.models import Abi, AbiSource
 from ...services.abis import AbiService
 from ...tests.datasources.db.db_async_conn import DbAsyncConn
@@ -11,6 +12,7 @@ class TestAbiService(DbAsyncConn):
         await super().asyncSetUp()
         self.abi_service = AbiService()
 
+    @db_session_context
     async def test_load_local_abis_in_database(self):
         self.assertEqual(await AbiSource.get_all(), [])
         self.assertEqual(await Abi.get_all(), [])

--- a/app/tests/services/test_abis.py
+++ b/app/tests/services/test_abis.py
@@ -1,8 +1,5 @@
 from collections import Counter
 
-from sqlmodel.ext.asyncio.session import AsyncSession
-
-from ...datasources.db.database import database_session
 from ...datasources.db.models import Abi, AbiSource
 from ...services.abis import AbiService
 from ...tests.datasources.db.db_async_conn import DbAsyncConn
@@ -14,22 +11,21 @@ class TestAbiService(DbAsyncConn):
         await super().asyncSetUp()
         self.abi_service = AbiService()
 
-    @database_session
-    async def test_load_local_abis_in_database(self, session: AsyncSession):
-        self.assertEqual(await AbiSource.get_all(session), [])
-        self.assertEqual(await Abi.get_all(session), [])
+    async def test_load_local_abis_in_database(self):
+        self.assertEqual(await AbiSource.get_all(), [])
+        self.assertEqual(await Abi.get_all(), [])
 
-        await self.abi_service.load_local_abis_in_database(session)
-        self.assertEqual(len(await AbiSource.get_all(session)), 1)
-        abis = await Abi.get_all(session)
+        await self.abi_service.load_local_abis_in_database()
+        self.assertEqual(len(await AbiSource.get_all()), 1)
+        abis = await Abi.get_all()
         self.assertEqual(len(abis), 152)
         relevance_counts = Counter(abi.relevance for abi in abis)
         self.assertEqual(relevance_counts[100], 5)
         self.assertEqual(relevance_counts[90], 5)
         self.assertEqual(relevance_counts[50], 142)
 
-        await self.abi_service.load_local_abis_in_database(session)
-        self.assertEqual(len(await Abi.get_all(session)), 152)
+        await self.abi_service.load_local_abis_in_database()
+        self.assertEqual(len(await Abi.get_all()), 152)
 
     def test_get_safe_contracts_abis(self):
         abis = self.abi_service.get_safe_contracts_abis()

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -6,10 +6,9 @@ from dramatiq.middleware import AsyncIO
 from hexbytes import HexBytes
 from periodiq import PeriodiqMiddleware, cron
 from safe_eth.eth.utils import fast_to_checksum_address
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.config import settings
-from app.datasources.db.database import get_engine
+from app.datasources.db.database import session_context_decorator
 from app.datasources.db.models import Contract
 from app.services.contract_metadata_service import get_contract_metadata_service
 
@@ -38,78 +37,75 @@ def test_task(message: str) -> None:
 
 
 @dramatiq.actor
+@session_context_decorator
 async def get_contract_metadata_task(
     address: str, chain_id: int, skip_attemp_download: bool = False
 ):
-    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
-        contract_metadata_service = get_contract_metadata_service()
-        # Just try the first time, following retries should be scheduled
-        if (
-            skip_attemp_download
-            or await contract_metadata_service.should_attempt_download(
-                session, address, chain_id, 0
-            )
-        ):
+    contract_metadata_service = get_contract_metadata_service()
+    # Just try the first time, following retries should be scheduled
+    if skip_attemp_download or await contract_metadata_service.should_attempt_download(
+        address, chain_id, 0
+    ):
+        logger.info(
+            "Downloading contract metadata for contract=%s and chain=%s",
+            address,
+            chain_id,
+        )
+        # TODO Check if contract is MultiSend. In that case, get the transaction and decode it
+        contract_metadata = await contract_metadata_service.get_contract_metadata(
+            fast_to_checksum_address(address), chain_id
+        )
+        result = await contract_metadata_service.process_contract_metadata(
+            contract_metadata
+        )
+        if result:
             logger.info(
-                "Downloading contract metadata for contract=%s and chain=%s",
+                "Success download contract metadata for contract=%s and chain=%s",
                 address,
                 chain_id,
             )
-            # TODO Check if contract is MultiSend. In that case, get the transaction and decode it
-            contract_metadata = await contract_metadata_service.get_contract_metadata(
-                fast_to_checksum_address(address), chain_id
-            )
-            result = await contract_metadata_service.process_contract_metadata(
-                session, contract_metadata
-            )
-            if result:
-                logger.info(
-                    "Success download contract metadata for contract=%s and chain=%s",
-                    address,
-                    chain_id,
-                )
-            else:
-                logger.info(
-                    "Failed to download contract metadata for contract=%s and chain=%s",
-                    address,
-                    chain_id,
-                )
-
-            if proxy_implementation_address := contract_metadata_service.get_proxy_implementation_address(
-                contract_metadata
-            ):
-                logger.info(
-                    "Adding task to download proxy implementation metadata from address=%s for contract=%s and chain=%s",
-                    proxy_implementation_address,
-                    address,
-                    chain_id,
-                )
-                get_contract_metadata_task.send(
-                    address=proxy_implementation_address, chain_id=chain_id
-                )
         else:
-            logger.debug("Skipping contract=%s and chain=%s", address, chain_id)
+            logger.info(
+                "Failed to download contract metadata for contract=%s and chain=%s",
+                address,
+                chain_id,
+            )
+
+        if proxy_implementation_address := contract_metadata_service.get_proxy_implementation_address(
+            contract_metadata
+        ):
+            logger.info(
+                "Adding task to download proxy implementation metadata from address=%s for contract=%s and chain=%s",
+                proxy_implementation_address,
+                address,
+                chain_id,
+            )
+            get_contract_metadata_task.send(
+                address=proxy_implementation_address, chain_id=chain_id
+            )
+    else:
+        logger.debug("Skipping contract=%s and chain=%s", address, chain_id)
 
 
 @dramatiq.actor(periodic=cron("0 0 * * *"))  # Every midnight
+@session_context_decorator
 async def get_missing_contract_metadata_task():
-    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
-        async for contract in Contract.get_contracts_without_abi(
-            session, settings.CONTRACT_MAX_DOWNLOAD_RETRIES
-        ):
-            get_contract_metadata_task.send(
-                address=HexBytes(contract.address).hex(),
-                chain_id=contract.chain_id,
-                skip_attemp_download=True,
-            )
+    async for contract in Contract.get_contracts_without_abi(
+        settings.CONTRACT_MAX_DOWNLOAD_RETRIES
+    ):
+        get_contract_metadata_task.send(
+            address=HexBytes(contract.address).hex(),
+            chain_id=contract.chain_id,
+            skip_attemp_download=True,
+        )
 
 
 @dramatiq.actor(periodic=cron("0 5 * * *"))  # Every day at 5 am
+@session_context_decorator
 async def update_proxies_task():
-    async with AsyncSession(get_engine(), expire_on_commit=False) as session:
-        async for proxy_contract in Contract.get_proxy_contracts(session):
-            get_contract_metadata_task.send(
-                address=HexBytes(proxy_contract.address).hex(),
-                chain_id=proxy_contract.chain_id,
-                skip_attemp_download=True,
-            )
+    async for proxy_contract in Contract.get_proxy_contracts():
+        get_contract_metadata_task.send(
+            address=HexBytes(proxy_contract.address).hex(),
+            chain_id=proxy_contract.chain_id,
+            skip_attemp_download=True,
+        )


### PR DESCRIPTION
# Description
Database session was passed as argument for every function even if was no needed to maintain the same session by request, the same happened for the session initiated by any task on dramatiq worker. 

# Proposed solution
It uses `async_scoped_session` (an async session of scoped_session) you can read documentation about it [here](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.async_scoped_session).   
`async_scoped_session` requires a session factory as `async_sessionmaker` and an scopefunc that will define the session scope.   
For our use case I think that the better approach is define the scope inside of a context, so each coming request will create a new session and reuse it in any query to database. This is being achieved setting the context in a fastapi [midleware](https://github.com/safe-global/safe-decoder-service/compare/refactor_session?expand=1#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR70). So each request will share the same session without need pass the session for all the code.    
In case of tasks and tests a [decorator](https://github.com/safe-global/safe-decoder-service/compare/refactor_session?expand=1#diff-28b6796b563336a2d6c540f13667f4a27a9c63a6389a0b6b5b3be5f6f99bec1bR77) was created to define the session context, this decorator is a helper. 


