### PR TITLE
Fix unreadable address formatting issue

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,7 +1,9 @@
 import secrets
+from typing import cast
 
 from fastapi import FastAPI
 
+from safe_eth.eth.utils import fast_to_checksum_address
 from sqladmin import Admin, ModelView
 from sqladmin.authentication import AuthenticationBackend
 from starlette.requests import Request
@@ -48,6 +50,12 @@ class ContractAdmin(ModelView, model=Contract):
     column_list = [Contract.address, Contract.name, Contract.description]  # type: ignore
     form_include_pk = True
     icon = "fa-solid fa-file-contract"
+
+    column_formatters = {
+        cast(str, Contract.address): lambda m, a: fast_to_checksum_address(
+            cast(Contract, m).address
+        ),
+    }
 
     async def on_model_change(
         self, data: dict, model: Contract, is_created: bool, request: Request


### PR DESCRIPTION
###  Description
Admin contracts was printing address as bytes, this PR format the address to return a Checksumed string address.
![image](https://github.com/user-attachments/assets/470215d9-a2c4-4093-95db-7cadbe18f9a9)


