### PR TITLE
Disable Uvicorn logs

### DIFF
--- a/docker/web/run_web.sh
+++ b/docker/web/run_web.sh
@@ -10,4 +10,4 @@ cp -r static/ $DOCKER_SHARED_DIR/
 echo "==> $(date +%H:%M:%S) ==> Running migrations..."
 alembic upgrade head
 echo "==> $(date +%H:%M:%S) ==> Running Uvicorn... "
-exec uvicorn app.main:app --host 0.0.0.0 --port 8888 --proxy-headers --forwarded-allow-ips='*' --uds $DOCKER_SHARED_DIR/uvicorn.socket
+exec uvicorn app.main:app --host 0.0.0.0 --port 8888 --proxy-headers --forwarded-allow-ips='*' --uds $DOCKER_SHARED_DIR/uvicorn.socket --no-access-log


### PR DESCRIPTION
Uvicorn logs are being duplicated because now we log the request on app side. 
