### PR TITLE
Refactor automatic ABI reload

### DIFF
--- a/app/datasources/db/models.py
+++ b/app/datasources/db/models.py
@@ -134,18 +134,16 @@ class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
             yield cast(ABI, result)
 
     @classmethod
-    async def get_abi_newer_equal_than(
-        cls, when: datetime.datetime
-    ) -> AsyncIterator[ABI]:
+    async def get_abi_newer_than(cls, when: datetime.datetime) -> AsyncIterator[ABI]:
         """
-        Get ABI json with `created` newer or equal than provided `when` parameter.
+        Get ABI json with `created` newer than provided `when` parameter.
 
         :param when: It will be compared with ABI `created` field
         :return: Abi JSONs, sorted by the oldest ones first
         """
         results = await db_session.execute(
             select(cls.abi_json)
-            .where(col(cls.created) >= when)
+            .where(col(cls.created) > when)
             .order_by(col(cls.created).asc())
         )
         for result in results.scalars().all():

--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -506,7 +506,7 @@ class DataDecoderService:
         last_abi_created = self.last_abi_created
         self.last_abi_created = await Abi.get_creation_date_for_last_inserted()
         if last_abi_created is not None:
-            abis = Abi.get_abi_newer_equal_than(last_abi_created)
+            abis = Abi.get_abi_newer_than(last_abi_created)
         else:
             abis = Abi.get_abis_sorted_by_relevance()
 

--- a/app/tests/datasources/db/test_model.py
+++ b/app/tests/datasources/db/test_model.py
@@ -135,10 +135,10 @@ class TestModel(DbAsyncConn):
         self.assertEqual(result, abi_jsons[0])
 
     @db_session_context
-    async def test_abi_get_abi_newer_equal_than(self):
-        current_datetime = datetime.datetime.now(tz=datetime.timezone.utc)
+    async def test_abi_get_abi_newer_than(self):
+        initial_datetime = datetime.datetime.now(tz=datetime.timezone.utc)
         self.assertListEqual(
-            [x async for x in Abi.get_abi_newer_equal_than(current_datetime)], []
+            [x async for x in Abi.get_abi_newer_than(initial_datetime)], []
         )
 
         abi_jsons = [
@@ -166,22 +166,22 @@ class TestModel(DbAsyncConn):
         self.assertListEqual(
             [
                 x
-                async for x in Abi.get_abi_newer_equal_than(
+                async for x in Abi.get_abi_newer_than(
                     datetime.datetime.now(tz=datetime.timezone.utc)
                 )
             ],
             [],
         )
         self.assertListEqual(
-            [x async for x in Abi.get_abi_newer_equal_than(last_abi.created)],
+            [x async for x in Abi.get_abi_newer_than(last_abi.created)],
+            [],
+        )
+        self.assertListEqual(
+            [x async for x in Abi.get_abi_newer_than(abi.created)],
             [last_abi.abi_json],
         )
         self.assertListEqual(
-            [x async for x in Abi.get_abi_newer_equal_than(abi.created)],
-            [abi.abi_json, last_abi.abi_json],
-        )
-        self.assertListEqual(
-            [x async for x in Abi.get_abi_newer_equal_than(current_datetime)],
+            [x async for x in Abi.get_abi_newer_than(initial_datetime)],
             [abi.abi_json, last_abi.abi_json],
         )
 


### PR DESCRIPTION
- Previously ABI reload was always loading at least the last one
- Currently we only return new ABIs. It would be very unlikely that an ABI is inserted exactly with the same timestamp than a previous one and it's ignored during reloading
