### PR TITLE
Replace uvicorn with gunicorn for production

### DIFF
--- a/docker/web/run_web.sh
+++ b/docker/web/run_web.sh
@@ -2,12 +2,13 @@
 
 set -euo pipefail
 
-echo "==> $(date +%H:%M:%S) ==> Collecting statics... "
 DOCKER_SHARED_DIR=/nginx
+
+echo "==> $(date +%H:%M:%S) ==> Collecting statics... "
 rm -rf $DOCKER_SHARED_DIR/*
 cp -r static/ $DOCKER_SHARED_DIR/
 
 echo "==> $(date +%H:%M:%S) ==> Running migrations..."
 alembic upgrade head
 echo "==> $(date +%H:%M:%S) ==> Running Uvicorn... "
-exec uvicorn app.main:app --host 0.0.0.0 --port 8888 --proxy-headers --forwarded-allow-ips='*' --uds $DOCKER_SHARED_DIR/uvicorn.socket --no-access-log
+exec gunicorn -k uvicorn.workers.UvicornWorker -b unix:$DOCKER_SHARED_DIR/uvicorn.socket -b 0.0.0.0:8888 app.main:app

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -5,10 +5,12 @@ asyncpg==0.30.0
 dramatiq[redis, watch]==1.17.1
 fastapi-camelcase==2.0.0
 fastapi[all]==0.115.12
+gunicorn==23.0.0
 periodiq==0.13.0
 pydantic-settings==2.9.1
 redis[hiredis]==5.2.1
 safe-eth-py==7.2.0
 sqladmin[full]==0.20.1
 sqlmodel==0.0.24
+uvicorn-worker==0.3.0
 web3==7.10.0


### PR DESCRIPTION
- It's now recommended by uvicorn to do so: https://www.uvicorn.org/deployment/
- We already have gunicorn experience
