### PR TITLE
Fix contracts without name

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.7.0"
+VERSION = "1.7.1"

--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -52,7 +52,7 @@ class AbiPublic(CamelModel):
 
 class ContractsPublic(CamelModel):
     address: ChecksumAddress
-    name: str
+    name: str | None
     display_name: str | None
     chain_id: int
     project: ProjectPublic | None

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -85,6 +85,19 @@ class TestRouterContract(AsyncDbTestCase):
         self.assertEqual(response_json["count"], 1)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["chainId"], 5)
+        # name could be None
+        contract_without_name = "0xD1a2a63a9766673940B4D2d7cB16259876Aca8a2"
+        contract = Contract(
+            address=HexBytes(contract_without_name), chain_id=1, fetch_retries=2
+        )
+        await contract.create()
+        response = self.client.get(
+            f"/api/v1/contracts/{contract_without_name}",
+        )
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertEqual(response_json["count"], 1)
+        self.assertIsNone(response_json["results"][0]["abi"])
 
     @db_session_context
     async def test_contracts_pagination(self):


### PR DESCRIPTION
# Description
Contracts without validation does not contains name.  
Set version to v1.7.1