### PR TITLE
Fix warnings

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -12,6 +12,7 @@ script_location = migrations
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
 prepend_sys_path = .
+path_separator = os
 
 # timezone to use when rendering the date within the migration file
 # as well as the filename.

--- a/app/tests/workers/test_tasks.py
+++ b/app/tests/workers/test_tasks.py
@@ -13,7 +13,7 @@ from safe_eth.eth.utils import fast_to_checksum_address
 
 from app.datasources.db.database import db_session, db_session_context
 from app.datasources.db.models import AbiSource, Contract
-from app.workers.tasks import get_contract_metadata_task, redis_broker, test_task
+from app.workers.tasks import get_contract_metadata_task, redis_broker, task_to_test
 
 from ...datasources.cache.redis import get_redis
 from ...services.contract_metadata_service import ContractMetadataService
@@ -43,7 +43,7 @@ class TestTasks(unittest.TestCase):
         self.assertEqual(len(redis_tasks), 0)
 
         test_message = "Task in Redis Queue"
-        test_task.send(test_message)
+        task_to_test.send(test_message)
 
         redis_tasks = redis_broker.client.lrange("dramatiq:default", 0, -1)
         assert isinstance(redis_tasks, list)
@@ -53,7 +53,7 @@ class TestTasks(unittest.TestCase):
         assert isinstance(task_info_raw, bytes)
         task_info = json.loads(task_info_raw)
         self.assertEqual(task_info.get("args"), [test_message])
-        self.assertEqual(task_info.get("actor_name"), "test_task")
+        self.assertEqual(task_info.get("actor_name"), "task_to_test")
 
         self.worker.start()
 

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -43,14 +43,14 @@ dramatiq.set_broker(redis_broker)
 
 
 @dramatiq.actor
-def test_task(message: str) -> None:
+def task_to_test(message: str) -> None:
     """
     Examples of use:
 
         from periodiq import cron
         @dramatiq.actor(periodic=cron("*/2 * * * *"))
 
-        async def test_task(message: str) -> None:
+        async def task_to_test(message: str) -> None:
     """
     logger.info(f"Message processed! -> {message}")
     return


### PR DESCRIPTION
Fixed:

```
venv/lib/python3.13/site-packages/dramatiq/actor.py:172
  /Users/felipe/Workspace/dev/safe-decoder-service/venv/lib/python3.13/site-packages/dramatiq/actor.py:172: PytestCollectionWarning: cannot collect 'test_task' because it is not a function.
    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Any | R | Awaitable[R]:

app/tests/datasources/db/test_migrations.py::TestMigrations::test_migration_rename_trusted_for_delegate
app/tests/datasources/db/test_migrations.py::TestMigrations::test_migration_rename_trusted_for_delegate
app/tests/datasources/db/test_migrations.py::TestMigrations::test_migration_rename_trusted_for_delegate
  /Users/felipe/Workspace/dev/safe-decoder-service/venv/lib/python3.13/site-packages/alembic/config.py:592: DeprecationWarning: No path_separator found in configuration; falling back to legacy splitting on spaces, commas, and colons for prepend_sys_path.  Consider adding path_separator=os to Alembic config.
    util.warn_deprecated(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

```
