### PR TITLE
fix: multiple bug fixes and performance optimizations

### DIFF
--- a/app/datasources/db/database.py
+++ b/app/datasources/db/database.py
@@ -91,7 +91,7 @@ def db_session_context(func):
                 return await func(*args, **kwargs)
             finally:
                 logger.debug(
-                    f"Removing session context: {_get_database_session_context()}"
+                    "Removing session context: %s", _get_database_session_context()
                 )
                 await db_session.remove()
 

--- a/app/datasources/db/models.py
+++ b/app/datasources/db/models.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncIterator
 from typing import Self, cast
 
 from eth_typing import ABI
-from sqlalchemy import DateTime, update
+from sqlalchemy import CursorResult, DateTime, update
 from sqlmodel import (
     JSON,
     Column,
@@ -388,6 +388,6 @@ class Contract(SqlQueryBase, TimeStampedSQLModel, table=True):
                 trusted_for_delegate_call=trusted_for_delegate_call,
             )
         )
-        result = await db_session.execute(query)
+        result = cast(CursorResult, await db_session.execute(query))
         await db_session.commit()
         return result.rowcount

--- a/app/datasources/queue/queue_provider.py
+++ b/app/datasources/queue/queue_provider.py
@@ -56,13 +56,15 @@ class QueueProvider:
         self._exchange = await channel.declare_exchange(
             settings.RABBITMQ_AMQP_EXCHANGE, ExchangeType.FANOUT, durable=True
         )
-        logger.info(f"Connected to {settings.RABBITMQ_AMQP_EXCHANGE} exchange")
+        logger.info("Connected to %s exchange", settings.RABBITMQ_AMQP_EXCHANGE)
         self._events_queue = await channel.declare_queue(
             settings.RABBITMQ_DECODER_EVENTS_QUEUE_NAME, durable=True
         )
         if self._events_queue:
             await self._events_queue.bind(self._exchange)
-        logger.info(f"Reading from {settings.RABBITMQ_DECODER_EVENTS_QUEUE_NAME} queue")
+        logger.info(
+            "Reading from %s queue", settings.RABBITMQ_DECODER_EVENTS_QUEUE_NAME
+        )
 
     async def connect(self, loop: AbstractEventLoop) -> None:
         """

--- a/app/main.py
+++ b/app/main.py
@@ -167,8 +167,6 @@ async def http_request_middleware(request: Request, call_next):
         response: Response | None = None
         try:
             response = await call_next(request)
-        except Exception as e:
-            raise e
         finally:
             await db_session.remove()
             # Log request

--- a/app/routers/data_decoder.py
+++ b/app/routers/data_decoder.py
@@ -34,16 +34,14 @@ async def data_decoder(input_data: DataDecoderInput) -> DataDecodedPublic:
     """
     data_decoder_service = await get_data_decoder_service()
 
-    # Load new ABIs from the database, don't await it so they are loaded while calling `get_data_decoded`
-    task_load_new_abis = data_decoder_service.load_new_abis()
+    # Load new ABIs from the database (runs before decoding to ensure fresh ABIs)
+    await data_decoder_service.load_new_abis()
 
     data_decoded = await data_decoder_service.get_data_decoded(
         input_data.data,
         address=cast(Address, input_data.to),
         chain_id=input_data.chain_id,
     )
-
-    await task_load_new_abis
     if data_decoded is None:
         raise HTTPException(
             status_code=404, detail="Cannot find function selector to decode data"

--- a/app/services/pagination.py
+++ b/app/services/pagination.py
@@ -68,7 +68,7 @@ class GenericPagination:
         :return:
         """
         queryset = await db_session.execute(query.offset(self.offset).limit(self.limit))
-        return queryset.scalars().all()
+        return list(queryset.scalars().all())
 
     async def get_count(self, query) -> int:
         """

--- a/app/services/safe_contracts_service.py
+++ b/app/services/safe_contracts_service.py
@@ -63,9 +63,11 @@ async def update_safe_contracts_info() -> None:
         )
         if affected_rows:
             logger.info(
-                f"Updated contract with address: {contract_address} in {affected_rows} chains"
+                "Updated contract with address: %s in %d chains",
+                contract_address,
+                affected_rows,
             )
         else:
             logger.warning(
-                f"Could not find any contract with address: {contract_address}"
+                "Could not find any contract with address: %s", contract_address
             )

--- a/app/tests/services/test_safe_contracts_service.py
+++ b/app/tests/services/test_safe_contracts_service.py
@@ -64,8 +64,11 @@ class TestContractMetadataService(unittest.IsolatedAsyncioTestCase):
         )
 
         mock_logger.info.assert_called_once_with(
-            "Updated contract with address: 0x9641d764fc13c8B624c04430C7356C1C7C8102e2 in 2 chains"
+            "Updated contract with address: %s in %d chains",
+            "0x9641d764fc13c8B624c04430C7356C1C7C8102e2",
+            2,
         )
         mock_logger.warning.assert_called_once_with(
-            "Could not find any contract with address: 0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526"
+            "Could not find any contract with address: %s",
+            "0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526",
         )

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -53,20 +53,20 @@ def task_to_test(message: str) -> None:
 
         async def task_to_test(message: str) -> None:
     """
-    logger.info(f"Message processed! -> {message}")
+    logger.info("Message processed! -> %s", message)
     return
 
 
 @dramatiq.actor
 @db_session_context
 async def get_contract_metadata_task(
-    address: str, chain_id: int, skip_attemp_download: bool = False
+    address: str, chain_id: int, skip_attempt_download: bool = False
 ):
     with logging_task_context(CurrentMessage.get_current_message()):
         contract_metadata_service = get_contract_metadata_service()
         # Just try the first time, following retries should be scheduled
         if (
-            skip_attemp_download
+            skip_attempt_download
             or await contract_metadata_service.should_attempt_download(
                 address, chain_id, 0
             )
@@ -112,7 +112,7 @@ async def get_missing_contract_metadata_task():
             get_contract_metadata_task.send(
                 address=to_0x_hex_str(contract.address),
                 chain_id=contract.chain_id,
-                skip_attemp_download=True,
+                skip_attempt_download=True,
             )
 
 
@@ -124,7 +124,7 @@ async def update_proxies_task():
             get_contract_metadata_task.send(
                 address=to_0x_hex_str(proxy_contract.address),
                 chain_id=proxy_contract.chain_id,
-                skip_attemp_download=True,
+                skip_attempt_download=True,
             )
 
 

--- a/migrations/versions/5ede7bdac949_init.py
+++ b/migrations/versions/5ede7bdac949_init.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2024-12-26 13:29:11.879091
 
 """
+# mypy: disable-error-code="attr-defined"
 
 from collections.abc import Sequence
 

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -10,6 +10,7 @@ periodiq==0.13.0
 pydantic-settings==2.11.0
 redis[hiredis]==6.4.0
 safe-eth-py==7.11.0
+setuptools>=75.0.0
 sqladmin[full]==0.21.0
 sqlmodel==0.0.25
 uvicorn-worker==0.4.0


### PR DESCRIPTION
Bug fixes:
- Fix typo: skip_attemp_download -> skip_attempt_download in tasks
- Fix unbound variable 'source' in contract_metadata_service when contract_metadata.source is None
- Remove useless exception re-raise in HTTP middleware

Performance optimizations:
- Batch ABI selector generation into single thread instead of spawning thread per selector
- Add 24h TTL to should_attempt_download Redis cache to allow retry of failed contract downloads
- Replace f-strings with lazy % formatting in logging calls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bug fixes and perf: handle missing ABI source, rename task flag, batch ABI selector generation; plus lazy logging, Redis TTL cache, and minor DB/typing tweaks.
> 
> - **Performance**:
>   - Batch ABI selector generation into a single background thread in `app/services/data_decoder.py`.
> - **Metadata Handling**:
>   - Safeguard missing `source` when metadata exists; increment retries and update contract in `app/services/contract_metadata_service.py`.
>   - Add 24h TTL cache for `should_attempt_download` (Redis) and cache negative decisions with expiry.
> - **API/Router**:
>   - Ensure fresh ABIs by awaiting `load_new_abis()` before decoding in `app/routers/data_decoder.py`.
> - **Workers/Tasks**:
>   - Rename `skip_attemp_download` -> `skip_attempt_download` across `app/workers/tasks.py` and callers.
> - **Middleware**:
>   - Remove redundant exception re-raise in `http_request_middleware` (`app/main.py`).
> - **Logging**:
>   - Replace f-strings with lazy `%s` formatting across modules (DB session, queue provider, workers, services, tests).
> - **DB/Typing**:
>   - Cast SQLAlchemy result to `CursorResult` in `Contract.update_contract_info` and minor scalar list handling in pagination.
> - **Migrations/Deps**:
>   - Add mypy directive in `migrations/...init.py`.
>   - Add `setuptools>=75.0.0` to `requirements-prod.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53a3fa38b566684bee909d94dcf70e0e25569f5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->