### PR TITLE
Catch OverflowError during ABI decoding

### DIFF
--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -292,8 +292,14 @@ class DataDecoderService:
                 [addresses_checksummed_normalizer], types, decoded
             )
             values = map(self._parse_decoded_arguments, normalized)
-        except (ValueError, DecodingError) as exc:
-            logger.warning("Cannot decode %s", to_0x_hex_str(data))
+        except (ValueError, DecodingError, ArithmeticError) as exc:
+            logger.warning(
+                "Cannot decode %s for address %s and chain-id %s",
+                to_0x_hex_str(data),
+                address,
+                chain_id,
+                exc_info=True,
+            )
             raise UnexpectedProblemDecoding(data) from exc
 
         return fn_abi["name"], list(zip(names, types, values, strict=False))  # type: ignore


### PR DESCRIPTION

Handle OverflowError that occurs when decoding malformed transaction data. This error is raised by eth_abi when dynamic type length fields contain values too large to fit in a platform index (e.g., corrupted data or 4-byte selector collisions where data doesn't match the resolved ABI).

Catching `ArithmeticError` (parent of `OverflowError`) ensures the service returns a proper error response instead of crashing with an unhandled exception.

