### PR TITLE
Fix: filter null addresses from contract metadata processing

### DIFF
--- a/app/datasources/db/models.py
+++ b/app/datasources/db/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import datetime
 from collections.abc import AsyncIterator
 from typing import Self, cast
@@ -47,17 +48,17 @@ class TimeStampedSQLModel(SQLModel):
 
     """
 
-    created: datetime.datetime = Field(
+    created: datetime.datetime = Field(  # type: ignore[call-overload]
         default_factory=lambda: datetime.datetime.now(datetime.UTC),
         nullable=False,
-        sa_type=DateTime(timezone=True),  # type: ignore
+        sa_type=DateTime(timezone=True),
         index=True,
     )
 
-    modified: datetime.datetime = Field(
+    modified: datetime.datetime = Field(  # type: ignore[call-overload]
         default_factory=lambda: datetime.datetime.now(datetime.UTC),
         nullable=False,
-        sa_type=DateTime(timezone=True),  # type: ignore
+        sa_type=DateTime(timezone=True),
         sa_column_kwargs={
             "onupdate": lambda: datetime.datetime.now(datetime.UTC),
         },

--- a/app/services/contract_metadata_service.py
+++ b/app/services/contract_metadata_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import enum
 import logging
 from dataclasses import dataclass
@@ -17,6 +18,7 @@ from safe_eth.eth.clients import (
     SourcifyClientConfigurationProblem,
 )
 from safe_eth.eth.clients.etherscan_client_v2 import AsyncEtherscanClientV2
+from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.eth.utils import fast_to_checksum_address
 
 from app.config import settings
@@ -194,7 +196,10 @@ class ContractMetadataService:
             )
             contract.abi_id = abi.id
             contract.name = contract_metadata.metadata.name
-            if contract_metadata.metadata.implementation:
+            if (
+                contract_metadata.metadata.implementation
+                and contract_metadata.metadata.implementation != NULL_ADDRESS
+            ):
                 contract.implementation = HexBytes(
                     contract_metadata.metadata.implementation
                 )
@@ -207,7 +212,11 @@ class ContractMetadataService:
     def get_proxy_implementation_address(
         contract_metadata: EnhancedContractMetadata,
     ) -> ChecksumAddress | None:
-        if contract_metadata.metadata and contract_metadata.metadata.implementation:
+        if (
+            contract_metadata.metadata
+            and contract_metadata.metadata.implementation
+            and contract_metadata.metadata.implementation != NULL_ADDRESS
+        ):
             return fast_to_checksum_address(contract_metadata.metadata.implementation)
         return None
 

--- a/app/services/events.py
+++ b/app/services/events.py
@@ -1,8 +1,10 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import json
 import logging
 
 from eth_typing import ChecksumAddress, HexStr
 from hexbytes import HexBytes
+from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.eth.utils import fast_is_checksum_address
 from safe_eth.safe.multi_send import MultiSend
 
@@ -58,6 +60,8 @@ class EventsService:
                             chain_id=chain_id
                         )
                     for contract_address in {to, *contracts_from_data}:
+                        if contract_address == NULL_ADDRESS:
+                            continue
                         get_contract_metadata_task.send(
                             address=contract_address, chain_id=chain_id
                         )

--- a/app/tests/services/test_contract_metadata.py
+++ b/app/tests/services/test_contract_metadata.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 from copy import copy
 from unittest import mock
 from unittest.mock import MagicMock
@@ -12,6 +13,7 @@ from safe_eth.eth.clients import (
     EtherscanClientConfigurationProblem,
     SourcifyClientConfigurationProblem,
 )
+from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.eth.utils import fast_to_checksum_address
 
 from app.datasources.db.database import db_session, db_session_context
@@ -303,6 +305,21 @@ class TestContractMetadataService(AsyncDbTestCase):
         )
         self.assertIsNone(
             ContractMetadataService.get_proxy_implementation_address(contract_data)
+        )
+
+        # NULL_ADDRESS implementation should be treated as no implementation
+        null_impl_contract_data = EnhancedContractMetadata(
+            address=random_address,
+            metadata=copy(etherscan_proxy_metadata_mock),
+            source=ContractSource.ETHERSCAN,
+            chain_id=1,
+        )
+        assert null_impl_contract_data.metadata is not None
+        null_impl_contract_data.metadata.implementation = str(NULL_ADDRESS)
+        self.assertIsNone(
+            ContractMetadataService.get_proxy_implementation_address(
+                null_impl_contract_data
+            )
         )
 
     @db_session_context

--- a/app/tests/services/test_events.py
+++ b/app/tests/services/test_events.py
@@ -1,8 +1,10 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import json
 import unittest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from eth_typing import HexStr
+from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.util.util import to_0x_hex_str
 
 from app.services.events import EventsService, logger
@@ -164,6 +166,40 @@ class TestEventsService(unittest.IsolatedAsyncioTestCase):
                 call(address="0x5B9ea52Aaa931D4EEf74C8aEaf0Fe759434FeD74", chain_id=1),
             ],
             any_order=True,
+        )
+
+    @patch("app.workers.tasks.get_contract_metadata_task.send")
+    @patch("app.services.events.get_safe_contract_service")
+    async def test_process_event_skips_null_address(
+        self,
+        mock_get_safe_contract_service: MagicMock,
+        mock_get_contract_metadata_task: MagicMock,
+    ):
+        mock_safe_contract_service = AsyncMock()
+        mock_safe_contract_service.safe_contracts_exist.return_value = True
+        mock_get_safe_contract_service.return_value = mock_safe_contract_service
+
+        real_address = "0x6ED857dc1da2c41470A95589bB482152000773e9"
+        valid_message = json.dumps(
+            {
+                "chainId": "1",
+                "type": "EXECUTED_MULTISIG_TRANSACTION",
+                "to": real_address,
+                "data": HexStr("0x1234"),
+            }
+        )
+
+        events_service = EventsService()
+        with patch.object(
+            events_service,
+            "get_contracts_from_data",
+            return_value={NULL_ADDRESS, real_address},
+        ):
+            await events_service.process_event(valid_message)
+
+        # NULL_ADDRESS should be filtered out; only real_address queued (once, as a set)
+        mock_get_contract_metadata_task.assert_called_once_with(
+            address=real_address, chain_id=1
         )
 
     @patch("app.workers.tasks.create_safe_contracts_task_for_new_chains.send")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - web
 
   db:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## Summary

- Skip `0x000...000` addresses in `EventsService.process_event` before queuing metadata tasks — these appear as the `to` address in ETH-only MultiSend batch transactions
- Guard against null implementation addresses in `ContractMetadataService` — external providers (Etherscan/Sourcify/Blockscout) sometimes return the zero address as the proxy implementation for non-proxy or uninitialized proxy contracts
- Fix pre-existing mypy errors in `models.py` surfaced by the uv migration (unused `type: ignore` comments and missing `# type: ignore[call-arg]` on `table=True` declarations)

Fixes PLA-1312