### PR TITLE
fix: migrate Redis client to redis.asyncio

### DIFF
--- a/app/datasources/cache/redis.py
+++ b/app/datasources/cache/redis.py
@@ -1,19 +1,30 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+import asyncio
 import hashlib
 import json
 from collections.abc import Callable
-from functools import cache, wraps
+from functools import wraps
 from typing import cast
+from weakref import WeakKeyDictionary
 
 from pydantic import BaseModel
-from redis import Redis
+from redis.asyncio import Redis
 
 from ...config import settings
 from ...utils import get_proxy_aware_url
 
+_redis_clients: WeakKeyDictionary[asyncio.AbstractEventLoop, Redis] = (
+    WeakKeyDictionary()
+)
 
-@cache
+
 def get_redis() -> Redis:
-    return Redis.from_url(settings.REDIS_URL)
+    loop = asyncio.get_running_loop()
+    redis = _redis_clients.get(loop)
+    if redis is None:
+        redis = Redis.from_url(settings.REDIS_URL)
+        _redis_clients[loop] = redis
+    return redis
 
 
 def get_key_for_contract(address: str, **kwargs) -> str:
@@ -27,14 +38,14 @@ def get_key_for_contract(address: str, **kwargs) -> str:
     return f"contract:{address.lower()}"
 
 
-def del_contract_cache(address: str):
+async def del_contract_cache(address: str):
     """
     Delete the Redis cache entry for a specific contract by address.
 
     :param address: The contract address used to build the cache key.
     :return: None
     """
-    get_redis().unlink(get_key_for_contract(address))
+    await get_redis().unlink(get_key_for_contract(address))
 
 
 def get_field_key(kwargs: dict) -> str:
@@ -86,7 +97,7 @@ def cache_response(
 
             # Try to fetch from Redis cache
             redis = get_redis()
-            cached_response = redis.hget(hash_key, field_key)
+            cached_response = await redis.hget(hash_key, field_key)  # type: ignore[misc]
             if cached_response:
                 # Return cached response if it exists
                 return json.loads(cast(str, cached_response))
@@ -97,12 +108,12 @@ def cache_response(
             # Store the response in cache for later
             # Force validation to trigger field validators that convert bytes
             validated_response = model.model_validate(response)
-            redis.hset(
+            await redis.hset(  # type: ignore[misc]
                 hash_key, field_key, validated_response.model_dump_json(by_alias=True)
             )
             # Set expiration just if is not configured
-            if redis.ttl(hash_key) == -1:
-                redis.expire(hash_key, expire)
+            if await redis.ttl(hash_key) == -1:
+                await redis.expire(hash_key, expire)
 
             return response
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import secrets
 from typing import cast
 
@@ -25,7 +26,7 @@ class AdminAuth(AuthenticationBackend):
             request.session.update({"token": secret})
 
             # Use redis to store the token
-            get_redis().set(
+            await get_redis().set(
                 f"admin:token:{secret}", 1, ex=settings.ADMIN_TOKEN_EXPIRATION_SECONDS
             )
 
@@ -42,7 +43,7 @@ class AdminAuth(AuthenticationBackend):
         if not secret:
             return False
 
-        return bool(get_redis().exists(f"admin:token:{secret}"))
+        return bool(await get_redis().exists(f"admin:token:{secret}"))
 
 
 class ContractAdmin(ModelView, model=Contract):

--- a/app/services/contract_metadata_service.py
+++ b/app/services/contract_metadata_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import enum
 import logging
 from dataclasses import dataclass
@@ -232,7 +233,7 @@ class ContractMetadataService:
             f"should_attempt_download:{contract_address}:{chain_id}:{max_retries}"
         )
         # Try from cache first
-        cached_retries: bytes = cast(bytes, redis.get(cache_key))
+        cached_retries: bytes = cast(bytes, await redis.get(cache_key))
         if cached_retries is not None:
             return bool(int(cached_retries.decode()))
         else:
@@ -242,7 +243,7 @@ class ContractMetadataService:
 
             if contract and (contract.fetch_retries > max_retries or contract.abi_id):
                 # Cache with TTL so contracts can be retried after cache expires
-                redis.set(
+                await redis.set(
                     cache_key,
                     0,
                     ex=ContractMetadataService.SHOULD_ATTEMPT_DOWNLOAD_CACHE_TTL,

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 from fastapi.testclient import TestClient
 from hexbytes import HexBytes
 
@@ -44,7 +45,7 @@ class TestRouterContract(AsyncDbTestCase):
         self.assertEqual(response_json["count"], 0)
 
         # Invalidate cache
-        del_contract_cache(address_expected)
+        await del_contract_cache(address_expected)
 
         # Should return cached response with count 0
         response = self.client.get(
@@ -63,7 +64,7 @@ class TestRouterContract(AsyncDbTestCase):
         await contract.update()
 
         # Invalidate cache
-        del_contract_cache(address_expected)
+        await del_contract_cache(address_expected)
 
         response = self.client.get(
             f"/api/v1/contracts/{address_expected}",
@@ -96,7 +97,7 @@ class TestRouterContract(AsyncDbTestCase):
         await contract.create()
 
         # Invalidate cache
-        del_contract_cache(address_expected)
+        await del_contract_cache(address_expected)
 
         response = self.client.get(
             f"/api/v1/contracts/{address_expected}?chain_ids=5",
@@ -115,7 +116,7 @@ class TestRouterContract(AsyncDbTestCase):
         await contract.create()
 
         # Invalidate cache
-        del_contract_cache(address_expected)
+        await del_contract_cache(address_expected)
 
         response = self.client.get(
             f"/api/v1/contracts/{contract_without_name}",

--- a/app/tests/workers/test_tasks.py
+++ b/app/tests/workers/test_tasks.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import json
 import unittest
 from collections.abc import Awaitable
@@ -79,7 +80,7 @@ class TestAsyncTasks(AsyncDbTestCase):
         await super().asyncTearDown()
         self.worker.stop()
         redis = get_redis()
-        redis.flushall()
+        await redis.flushall()
 
     def _wait_tasks_execution(self):
         # Ensure that all the messages on redis were consumed
@@ -105,7 +106,7 @@ class TestAsyncTasks(AsyncDbTestCase):
         chain_id = 100
         cache_key = f"should_attempt_download:{contract_address}:{chain_id}:0"
         redis = get_redis()
-        redis.delete(cache_key)
+        await redis.delete(cache_key)
         await AbiSource(name="Etherscan", url="").create()
         etherscan_get_contract_metadata_mock.return_value = None
         mock_enabled_clients.return_value = [
@@ -131,7 +132,7 @@ class TestAsyncTasks(AsyncDbTestCase):
 
         # After reset cache and database retries should download the contract
         contract.fetch_retries = 0
-        redis.delete(cache_key)
+        await redis.delete(cache_key)
         await contract.update()
         get_contract_metadata_task.send(address=contract_address, chain_id=chain_id)
         self._wait_tasks_execution()
@@ -194,7 +195,7 @@ class TestAsyncTasks(AsyncDbTestCase):
 
         lock_key = f"lock:create_safe_contracts:{new_chain_id}"
         redis = get_redis()
-        redis.delete(lock_key)
+        await redis.delete(lock_key)
 
         create_safe_contracts_task_for_new_chains.send(chain_id=new_chain_id)
         self._wait_tasks_execution()
@@ -220,7 +221,7 @@ class TestAsyncTasks(AsyncDbTestCase):
         )
         self.assertTrue(exists_after)
 
-        self.assertFalse(redis.exists(lock_key))
+        self.assertFalse(await redis.exists(lock_key))
 
     @db_session_context
     async def test_create_safe_contracts_task_with_lock_held(self):
@@ -228,7 +229,7 @@ class TestAsyncTasks(AsyncDbTestCase):
         lock_key = f"lock:create_safe_contracts:{new_chain_id}"
         redis = get_redis()
 
-        redis.set(lock_key, "1", ex=300)
+        await redis.set(lock_key, "1", ex=300)
 
         create_safe_contracts_task_for_new_chains.send(chain_id=new_chain_id)
         self._wait_tasks_execution()
@@ -237,4 +238,4 @@ class TestAsyncTasks(AsyncDbTestCase):
         chain_contracts = [c for c in contracts if c.chain_id == new_chain_id]
         self.assertEqual(len(chain_contracts), 0)
 
-        redis.delete(lock_key)
+        await redis.delete(lock_key)

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import logging
 
 import dramatiq
@@ -81,7 +82,7 @@ async def get_contract_metadata_task(
             if result:
                 logger.info("Success download contract metadata")
                 # Force invalidate contract cache view
-                del_contract_cache(address)
+                await del_contract_cache(address)
             else:
                 logger.info("Failed to download contract metadata")
 
@@ -141,7 +142,7 @@ async def create_safe_contracts_task_for_new_chains(chain_id: int):
     with logging_task_context(CurrentMessage.get_current_message()):
         lock_key = f"lock:create_safe_contracts:{chain_id}"
         redis = get_redis()
-        lock_acquired = redis.set(lock_key, "1", nx=True, ex=300)
+        lock_acquired = await redis.set(lock_key, "1", nx=True, ex=300)
 
         if not lock_acquired:
             logger.debug(
@@ -154,4 +155,4 @@ async def create_safe_contracts_task_for_new_chains(chain_id: int):
             logger.info("Creating Safe contracts for chain %d", chain_id)
             await safe_contract_service.create_safe_contracts(chain_id=chain_id)
         finally:
-            redis.delete(lock_key)
+            await redis.delete(lock_key)


### PR DESCRIPTION
## Problem

All Redis calls in the codebase used the **synchronous** `redis.Redis` client inside async functions, blocking the asyncio event loop on every cache read/write, admin token check, and distributed-lock operation. Under load this serialises the entire web worker.

## Changes

- `app/datasources/cache/redis.py` — import `redis.asyncio.Redis`; `await` every call in `cache_response` and `del_contract_cache`
- `app/routers/admin.py` — `await` the token `set` and `exists` calls in `AdminAuth`
- `app/services/contract_metadata_service.py` — `await` the `get`/`set` calls in `should_attempt_download`
- `app/workers/tasks.py` — `await` the distributed-lock `set`/`delete` in `create_safe_contracts_task_for_new_chains` and `del_contract_cache`
- `app/tests/routers/test_contracts.py` — `await del_contract_cache(...)` in test helpers

## Notes

redis-py 6 ships shared stubs where `hget`/`hset` are typed `Awaitable[T] | T` (covering both sync and async clients). Two `# type: ignore[misc]` comments silence the false-positive mypy error; `ttl`/`expire` resolved cleanly with no annotation needed.

Fixes PLA-1311