### PR TITLE
fix: invalidate per-contract ABI cache after metadata update

### DIFF
--- a/app/services/contract_metadata_service.py
+++ b/app/services/contract_metadata_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import enum
 import logging
 from dataclasses import dataclass
@@ -22,6 +23,7 @@ from safe_eth.eth.utils import fast_to_checksum_address
 from app.config import settings
 from app.datasources.cache.redis import get_redis
 from app.datasources.db.models import Abi, AbiSource, Contract
+from app.services.data_decoder import get_data_decoder_service
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +200,14 @@ class ContractMetadataService:
                 contract.implementation = HexBytes(
                     contract_metadata.metadata.implementation
                 )
+
+            # Evict stale per-contract ABI cache entries so the decoder
+            # picks up the newly linked ABI on the next request.
+            decoder = await get_data_decoder_service()
+            decoder.invalidate_contract_abi_cache(
+                contract_metadata.address,
+                contract_metadata.chain_id,
+            )
 
         contract.fetch_retries += 1
         await contract.update()

--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -175,7 +175,7 @@ class DataDecoderService:
     async def get_multisend_abis(self) -> AsyncIterator[ABI]:
         yield get_multi_send_contract(self.dummy_w3).abi
 
-    @alru_cache(maxsize=2048)
+    @alru_cache(maxsize=2048, ttl=600)
     async def get_contract_abi(
         self,
         address: Address,
@@ -190,7 +190,7 @@ class DataDecoderService:
         """
         return await Contract.get_abi_by_contract_address(HexBytes(address), chain_id)
 
-    @alru_cache(maxsize=2048)
+    @alru_cache(maxsize=2048, ttl=600)
     async def get_contract_abi_selectors_with_functions(
         self, address: Address, chain_id: int | None
     ) -> dict[bytes, ABIFunction] | None:
@@ -497,6 +497,24 @@ class DataDecoderService:
             if await self.get_contract_abi(address, None):
                 return DecodingAccuracyEnum.PARTIAL_MATCH
         return DecodingAccuracyEnum.ONLY_FUNCTION_MATCH
+
+    def invalidate_contract_abi_cache(
+        self, address: Address | ChecksumAddress, chain_id: int | None
+    ) -> None:
+        """
+        Evict a specific contract from both per-contract ABI caches.
+
+        Call this whenever a contract's ABI is updated in the database so
+        that the next decode request re-fetches the latest ABI rather than
+        serving stale data from the in-memory cache.
+
+        :param address: Contract address
+        :param chain_id: Chain id for the contract
+        """
+        self.get_contract_abi.cache_invalidate(self, address, chain_id)
+        self.get_contract_abi_selectors_with_functions.cache_invalidate(
+            self, address, chain_id
+        )
 
     async def add_abi(self, abi: ABI) -> bool:
         """


### PR DESCRIPTION
## Problem

`DataDecoderService.get_contract_abi` and `get_contract_abi_selectors_with_functions` were decorated with `@alru_cache(maxsize=2048)` with no TTL and no invalidation. When a contract's ABI was updated in the database (e.g. after a proxy implementation refresh via `update_proxies_task`), the in-memory cache continued returning the old ABI for the lifetime of the process.

## Changes

**`app/services/data_decoder.py`**
- Add `ttl=600` to both `@alru_cache` decorators — stale entries expire within 10 minutes automatically.
- Add `invalidate_contract_abi_cache(address, chain_id)` which calls `cache_invalidate` on both caches for the given contract, enabling immediate eviction.

**`app/services/contract_metadata_service.py`**
- After successfully linking a new ABI to a contract in `process_contract_metadata`, call `decoder.invalidate_contract_abi_cache(...)` so the next decode request fetches the fresh ABI without waiting for the TTL.