### PR TITLE
fix: replace timestamp cursor in load_new_abis with monotonic id cursor

### DIFF
--- a/app/datasources/db/models.py
+++ b/app/datasources/db/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import datetime
 from collections.abc import AsyncIterator
 from typing import Self, cast
@@ -113,12 +114,12 @@ class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
     contracts: list["Contract"] = Relationship(back_populates="abi")
 
     @classmethod
-    async def get_creation_date_for_last_inserted(cls) -> datetime.datetime | None:
+    async def get_last_inserted_id(cls) -> int | None:
         """
-        :return: Creation date for last inserted ABI, `None` if table is empty
+        :return: The `id` of the most recently inserted ABI, `None` if the table is empty.
         """
         results = await db_session.execute(
-            select(cls.created).order_by(col(cls.created).desc()).limit(1)
+            select(cls.id).order_by(col(cls.id).desc()).limit(1)
         )
         if result := results.first():
             return result[0]
@@ -136,17 +137,22 @@ class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
             yield cast(ABI, result)
 
     @classmethod
-    async def get_abi_newer_than(cls, when: datetime.datetime) -> AsyncIterator[ABI]:
+    async def get_abis_with_id_greater_than(cls, last_id: int) -> AsyncIterator[ABI]:
         """
-        Get ABI json with `created` newer than provided `when` parameter.
+        Get ABI json for rows whose `id` is strictly greater than `last_id`.
 
-        :param when: It will be compared with ABI `created` field
-        :return: Abi JSONs, sorted by the oldest ones first
+        Using the autoincremental id as cursor instead of a timestamp avoids
+        the edge case where two ABIs share the same `created` timestamp and
+        the newer one would be permanently skipped by a strict `>` timestamp
+        comparison.
+
+        :param last_id: Exclusive lower bound on the `id` column.
+        :return: Abi JSONs ordered by ascending `id`.
         """
         results = await db_session.execute(
             select(cls.abi_json)
-            .where(col(cls.created) > when)
-            .order_by(col(cls.created).asc())
+            .where(col(cls.id) > last_id)
+            .order_by(col(cls.id).asc())
         )
         for result in results.scalars().all():
             yield cast(ABI, result)

--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 import asyncio
-import datetime
 import logging
 from collections.abc import AsyncIterator
 from enum import Enum
@@ -99,7 +98,7 @@ class DataDecoderService:
     fn_selectors_with_abis: dict[bytes, ABIFunction]
     multisend_abis: list[ABI]
     multisend_fn_selectors_with_abis: dict[bytes, ABIFunction]
-    last_abi_created: datetime.datetime | None
+    last_abi_id: int | None
 
     async def init(self) -> None:
         """
@@ -107,12 +106,13 @@ class DataDecoderService:
         in memory
         """
 
-        # last_abi_created will be used to reload ABIs on the database only getting the newer ones
-        self.last_abi_created = await Abi.get_creation_date_for_last_inserted()
+        # last_abi_id is used as a monotonic cursor to reload only new ABIs on
+        # subsequent calls, avoiding the timestamp-collision edge case.
+        self.last_abi_id = await Abi.get_last_inserted_id()
         logger.info(
-            "%s: Loading contract ABIs for decoding. Last inserted ABI on the database: %s",
+            "%s: Loading contract ABIs for decoding. Last inserted ABI id on the database: %s",
             self.__class__.__name__,
-            self.last_abi_created,
+            self.last_abi_id,
         )
         self.fn_selectors_with_abis: dict[
             bytes, ABIFunction
@@ -516,7 +516,8 @@ class DataDecoderService:
     async def load_new_abis(self) -> int:
         """
         Load new ABIs stored on the database after the decoder was started.
-        Use `last_abi_created` property to only load the latest ABIs
+        Uses a monotonic `id` cursor (``last_abi_id``) so that ABIs inserted
+        with identical timestamps are never skipped.
 
         :return: Number of new ABIs loaded
         """
@@ -528,18 +529,18 @@ class DataDecoderService:
                 "%s: Reloading contract ABIs",
                 self.__class__.__name__,
             )
-            previous_last_abi_created = self.last_abi_created
-            self.last_abi_created = await Abi.get_creation_date_for_last_inserted()
-            if not previous_last_abi_created:
+            previous_last_abi_id = self.last_abi_id
+            self.last_abi_id = await Abi.get_last_inserted_id()
+            if previous_last_abi_id is None:
                 # No reference to compare, so we get all the ABIs
                 abis = Abi.get_abis_sorted_by_relevance()
             else:
                 if (
-                    self.last_abi_created
-                    and self.last_abi_created > previous_last_abi_created
+                    self.last_abi_id is not None
+                    and self.last_abi_id > previous_last_abi_id
                 ):
                     # Only reload if new ABIs were inserted
-                    abis = Abi.get_abi_newer_than(previous_last_abi_created)
+                    abis = Abi.get_abis_with_id_greater_than(previous_last_abi_id)
                 else:
                     logger.debug(
                         "%s: No new contract ABIs to load",

--- a/app/tests/datasources/db/test_models.py
+++ b/app/tests/datasources/db/test_models.py
@@ -1,4 +1,4 @@
-import datetime
+# SPDX-License-Identifier: FSL-1.1-MIT
 from typing import cast
 
 from eth_account import Account
@@ -120,8 +120,8 @@ class TestModels(AsyncDbTestCase):
         self.assertEqual(result[0], abi)
 
     @db_session_context
-    async def test_abi_get_creation_date_for_last_inserted(self):
-        self.assertIsNone(await Abi.get_creation_date_for_last_inserted())
+    async def test_abi_get_last_inserted_id(self):
+        self.assertIsNone(await Abi.get_last_inserted_id())
 
         abi_jsons = [
             {"name": "A Test Project with relevance 100"},
@@ -145,8 +145,8 @@ class TestModels(AsyncDbTestCase):
         )
         await last_abi.create()
 
-        last_inserted = await Abi.get_creation_date_for_last_inserted()
-        self.assertEqual(last_inserted, last_abi.created)
+        last_inserted = await Abi.get_last_inserted_id()
+        self.assertEqual(last_inserted, last_abi.id)
 
     @db_session_context
     async def test_abi_get_abis_sorted_by_relevance(self):
@@ -181,10 +181,9 @@ class TestModels(AsyncDbTestCase):
         self.assertEqual(result, abi_jsons[0])
 
     @db_session_context
-    async def test_abi_get_abi_newer_than(self):
-        initial_datetime = datetime.datetime.now(tz=datetime.UTC)
+    async def test_abi_get_abis_with_id_greater_than(self):
         self.assertListEqual(
-            [x async for x in Abi.get_abi_newer_than(initial_datetime)], []
+            [x async for x in Abi.get_abis_with_id_greater_than(0)], []
         )
 
         abi_jsons = [
@@ -209,25 +208,18 @@ class TestModels(AsyncDbTestCase):
         )
         await last_abi.create()
 
+        assert abi.id is not None
+        assert last_abi.id is not None
         self.assertListEqual(
-            [
-                x
-                async for x in Abi.get_abi_newer_than(
-                    datetime.datetime.now(tz=datetime.UTC)
-                )
-            ],
+            [x async for x in Abi.get_abis_with_id_greater_than(last_abi.id)],
             [],
         )
         self.assertListEqual(
-            [x async for x in Abi.get_abi_newer_than(last_abi.created)],
-            [],
-        )
-        self.assertListEqual(
-            [x async for x in Abi.get_abi_newer_than(abi.created)],
+            [x async for x in Abi.get_abis_with_id_greater_than(abi.id)],
             [last_abi.abi_json],
         )
         self.assertListEqual(
-            [x async for x in Abi.get_abi_newer_than(initial_datetime)],
+            [x async for x in Abi.get_abis_with_id_greater_than(0)],
             [abi.abi_json, last_abi.abi_json],
         )
 

--- a/app/tests/services/test_data_decoder.py
+++ b/app/tests/services/test_data_decoder.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 from eth_typing import Address
 from hexbytes import HexBytes
 from safe_eth.eth.constants import NULL_ADDRESS
@@ -636,18 +637,18 @@ class TestDataDecoderService(AsyncDbTestCase):
 
         # Service should not have any ABI loaded
         self.assertEqual(decoder_service.fn_selectors_with_abis, {})
-        self.assertIsNone(decoder_service.last_abi_created)
+        self.assertIsNone(decoder_service.last_abi_id)
 
         # Try to load new ABIs, none should be loaded
         self.assertEqual(await decoder_service.load_new_abis(), 0)
         self.assertEqual(decoder_service.fn_selectors_with_abis, {})
-        self.assertIsNone(decoder_service.last_abi_created)
+        self.assertIsNone(decoder_service.last_abi_id)
 
         # Store ABIs in the database and load them
         await self._store_safe_contract_abi()
         self.assertGreater(await decoder_service.load_new_abis(), 0)
         self.assertNotEqual(decoder_service.fn_selectors_with_abis, {})
-        self.assertIsNotNone(decoder_service.last_abi_created)
+        self.assertIsNotNone(decoder_service.last_abi_id)
 
         # No new ABIs to load
         # Store ABIs in the database and load them
@@ -668,4 +669,4 @@ class TestDataDecoderService(AsyncDbTestCase):
         self.assertGreater(
             len(decoder_service.fn_selectors_with_abis), len_previous_selectors
         )
-        self.assertEqual(decoder_service.last_abi_created, abi.created)
+        self.assertEqual(decoder_service.last_abi_id, abi.id)


### PR DESCRIPTION
## Problem

`load_new_abis` tracked the cursor as the `created` timestamp of the last loaded ABI and used `Abi.get_abi_newer_than(when)` with a strict `>` comparison. Two ABIs inserted in the same microsecond are indistinguishable by this cursor: the second one would be permanently skipped on subsequent calls.

## Changes

**`app/datasources/db/models.py`**
- Add `Abi.get_last_inserted_id()` — returns `max(id)`, the monotonically increasing primary key.
- Add `Abi.get_abis_with_id_greater_than(last_id)` — replaces `get_abi_newer_than`; orders by `id ASC` and uses `id > last_id`.
- Old methods `get_creation_date_for_last_inserted` and `get_abi_newer_than` removed.

**`app/services/data_decoder.py`**
- `last_abi_created: datetime | None` → `last_abi_id: int | None`.
- `load_new_abis` updated to use the new id-based queries.
- Unused `import datetime` removed.

Fixes PLA-1308