### PR TITLE
fix: only increment fetch_retries on failed ABI downloads

### DIFF
--- a/app/services/contract_metadata_service.py
+++ b/app/services/contract_metadata_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import enum
 import logging
 from dataclasses import dataclass
@@ -199,7 +200,8 @@ class ContractMetadataService:
                     contract_metadata.metadata.implementation
                 )
 
-        contract.fetch_retries += 1
+        if not contract_metadata.metadata:
+            contract.fetch_retries += 1
         await contract.update()
         return bool(contract_metadata.metadata)
 

--- a/app/tests/services/test_contract_metadata.py
+++ b/app/tests/services/test_contract_metadata.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 from copy import copy
 from unittest import mock
 from unittest.mock import MagicMock
@@ -177,7 +178,7 @@ class TestContractMetadataService(AsyncDbTestCase):
         self.assertIsNone(contract.implementation)
         self.assertEqual(contract.abi.abi_json, etherscan_metadata_mock.abi)
         self.assertEqual(contract.chain_id, 1)
-        self.assertEqual(contract.fetch_retries, 1)
+        self.assertEqual(contract.fetch_retries, 0)
 
         # New proxy contract
         proxy_contract_data = EnhancedContractMetadata(


### PR DESCRIPTION
`fetch_retries` was incremented unconditionally , including on the success path. It now only increments on failure

Fixes PLA-1307