### PR TITLE
fix: merge log_record_factory so both db_session and task_detail are injected

### DIFF
--- a/app/loggers/safe_logger.py
+++ b/app/loggers/safe_logger.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import datetime
 import logging
 import traceback
@@ -104,6 +105,29 @@ class SafeJsonFormatter(logging.Formatter):
 
 
 _task_info: ContextVar["TaskInfo"] = ContextVar("task_info")
+
+
+def log_record_factory(*args, **kwargs) -> logging.LogRecord:
+    """
+    Inject both db_session and task_detail into every log record.
+    """
+    record = logging.LogRecord(*args, **kwargs)
+    try:
+        from app.datasources.db.database import (  # noqa: PLC0415
+            _db_session_context,
+        )
+
+        record.db_session = _db_session_context.get()
+    except LookupError:
+        pass
+    try:
+        record.task_detail = _task_info.get()
+    except LookupError:
+        pass
+    return record
+
+
+logging.setLogRecordFactory(log_record_factory)
 
 
 @contextmanager

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import asyncio
 import datetime
 import logging
@@ -12,7 +13,6 @@ from app.loggers.safe_logger import HttpRequestLog, HttpResponseLog
 
 from . import VERSION
 from .datasources.db.database import (
-    _get_database_session_context,
     db_session,
     set_database_session_context,
 )
@@ -24,28 +24,6 @@ from .services.data_decoder import get_data_decoder_service
 from .services.events import EventsService
 
 logger = logging.getLogger()
-
-
-def log_record_factory_for_request(*args, **kwargs) -> logging.LogRecord:
-    """
-    Inject session database identifier in log record.
-
-    :param args:
-    :param kwargs:
-    :return:
-    """
-    # Create a log record with additional context
-    record = logging.LogRecord(*args, **kwargs)
-    try:
-        record.db_session = _get_database_session_context()
-    except LookupError:
-        # This error means that there is not session
-        pass
-
-    return record
-
-
-logging.setLogRecordFactory(log_record_factory_for_request)
 
 
 @asynccontextmanager

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import logging
 
 import dramatiq
@@ -11,29 +12,9 @@ from app.config import settings
 from app.datasources.cache.redis import del_contract_cache, get_redis
 from app.datasources.db.database import db_session_context
 from app.datasources.db.models import Contract
-from app.loggers.safe_logger import get_task_info, logging_task_context
+from app.loggers.safe_logger import logging_task_context
 from app.services.contract_metadata_service import get_contract_metadata_service
 from app.services.safe_contracts_service import get_safe_contract_service
-
-
-def log_record_factory_for_task(*args, **kwargs):
-    """
-    Injects to log record the task information.
-
-    :param args:
-    :param kwargs:
-    :return:
-    """
-    record = logging.LogRecord(*args, **kwargs)
-    try:
-        record.task_detail = get_task_info()
-    except LookupError:
-        pass
-    return record
-
-
-logging.setLogRecordFactory(log_record_factory_for_task)
-
 
 logger = logging.getLogger(__name__)
 redis_broker = RedisBroker(url=settings.REDIS_URL)


### PR DESCRIPTION
`main.py `and `workers/tasks.py` each registered their own log record factory via `logging.setLogRecordFactory`, with the last import winning. In the web process the task factory overwrote the request factory, causing `db_session` to be absent from web logs. A single factory is now defined in `safe_logger.py` and registered there; it lazily `resolves _db_session_context` to avoid the `config→safe_logger→database` circular import.

Fixes PLA-1306