### PR TITLE
fix: use nack(requeue=False) for unprocessable messages instead of ACK

### DIFF
--- a/app/datasources/queue/queue_provider.py
+++ b/app/datasources/queue/queue_provider.py
@@ -120,9 +120,9 @@ class QueueProvider:
             try:
                 if body:
                     await callback(body.decode("utf-8"))
+                await message.ack()
             except Exception:
                 logger.exception("Error processing message with body: %s", body)
-            finally:
-                await message.ack()
+                await message.nack(requeue=False)
 
         return await self._events_queue.consume(wrapped_callback)


### PR DESCRIPTION
Poison messages that raised an exception were silently ACKed and dropped. On failure the message is now nacked with requeue=False so it is routed to the dead-letter queue instead of being lost silently.

Fixes PLA-1305