### PR TITLE
fix: guard ContractAdmin.column_formatters against non-bytes address

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,7 +1,9 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import secrets
 from typing import cast
 
 from fastapi import FastAPI
+from hexbytes import HexBytes
 from safe_eth.eth.utils import fast_to_checksum_address
 from sqladmin import Admin, ModelView
 from sqladmin.authentication import AuthenticationBackend
@@ -52,7 +54,7 @@ class ContractAdmin(ModelView, model=Contract):
 
     column_formatters = {
         cast(str, Contract.address): lambda m, a: fast_to_checksum_address(
-            cast(Contract, m).address
+            HexBytes(cast(Contract, m).address)
         ),
     }
 


### PR DESCRIPTION
fast_to_checksum_address raises if given a hex string instead of bytes. Wrapping with HexBytes() accepts either form, making the formatter safe if SQLAdmin ever normalizes the column before passing it.

Fixes PLA-1302