### PR TITLE
Replace 4-byte MD5 abi_hash with PostgreSQL SHA-256 generated column

### DIFF
--- a/app/datasources/db/models.py
+++ b/app/datasources/db/models.py
@@ -1,10 +1,21 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 import datetime
+import json
 from collections.abc import AsyncIterator
 from typing import Self, cast
 
 from eth_typing import ABI
-from sqlalchemy import BigInteger, DateTime, func, update
+from sqlalchemy import (
+    BigInteger,
+    Computed,
+    DateTime,
+    LargeBinary,
+    func,
+    literal,
+    update,
+)
+from sqlalchemy import cast as sa_cast
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import (
@@ -20,7 +31,6 @@ from sqlmodel import (
 from sqlmodel.sql._expression_select_cls import SelectBase
 
 from .database import db_session
-from .utils import get_md5_abi_hash
 
 
 class SqlQueryBase:
@@ -103,7 +113,15 @@ class AbiSource(SqlQueryBase, SQLModel, table=True):
 
 class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
-    abi_hash: bytes | None = Field(nullable=False, index=True, unique=True)
+    abi_hash: bytes | None = Field(
+        default=None,
+        sa_column=Column(
+            LargeBinary,
+            Computed("sha256(abi_json::jsonb::text::bytea)", persisted=True),
+            index=True,
+            unique=True,
+        ),
+    )
     relevance: int | None = Field(nullable=False, default=0, index=True)
     abi_json: list[dict] | dict = Field(default_factory=dict, sa_column=Column(JSON))
     source_id: int | None = Field(
@@ -158,7 +176,6 @@ class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
             yield cast(ABI, abi_json)
 
     async def create(self):
-        self.abi_hash = get_md5_abi_hash(self.abi_json)
         return await self._save()
 
     @classmethod
@@ -167,21 +184,23 @@ class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
         abi_json: list[dict] | dict,
     ):
         """
-        Checks if an Abi exists based on the 'abi_json' by its calculated 'abi_hash'.
-        If it exists, returns the existing Abi. If not,
-        returns None.
+        Checks if an Abi with the given 'abi_json' exists using JSONB equality,
+        which normalises key ordering so the lookup is independent of how the
+        caller serialised the dict.
 
         :param abi_json: The ABI JSON to check.
         :return: The Abi object if it exists, or None if it doesn't.
         """
-        abi_hash = get_md5_abi_hash(abi_json)
-        query = select(cls).where(cls.abi_hash == abi_hash).limit(1)
+        query = (
+            select(cls)
+            .where(
+                sa_cast(cls.abi_json, JSONB)
+                == sa_cast(literal(json.dumps(abi_json)), JSONB)
+            )
+            .limit(1)
+        )
         result = await db_session.execute(query)
-
-        if existing_abi := result.scalars().first():
-            return existing_abi
-
-        return None
+        return result.scalars().first()
 
     @classmethod
     async def get_or_create_abi(
@@ -191,8 +210,9 @@ class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
         relevance: int | None = 0,
     ) -> tuple["Abi", bool]:
         """
-        Checks if an Abi with the given 'abi_json' exists.
-        If found, returns it with False. If not, creates and returns it with True.
+        Returns the existing Abi for the given 'abi_json' or creates a new one.
+        Deduplication is enforced by the unique index on the generated abi_hash
+        column; concurrent inserts are handled by catching IntegrityError.
 
         :param abi_json: The ABI JSON to check.
         :param relevance:
@@ -200,12 +220,16 @@ class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
         :return: A tuple containing the Abi object and a boolean indicating
                  whether it was created `True` or already exists `False`.
         """
-        if abi := await cls.get_abi(abi_json):
-            return abi, False
-        else:
-            new_item = cls(abi_json=abi_json, relevance=relevance, source_id=source_id)
+        new_item = cls(abi_json=abi_json, relevance=relevance, source_id=source_id)
+        try:
             await new_item.create()
             return new_item, True
+        except IntegrityError:
+            await db_session.rollback()
+            existing = await cls.get_abi(abi_json)
+            if existing is None:
+                raise
+            return existing, False
 
 
 class Project(SqlQueryBase, SQLModel, table=True):

--- a/app/datasources/db/models.py
+++ b/app/datasources/db/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Computed,
     DateTime,
     LargeBinary,
+    Text,
     func,
     literal,
     update,
@@ -184,21 +185,21 @@ class Abi(SqlQueryBase, TimeStampedSQLModel, table=True):
         abi_json: list[dict] | dict,
     ):
         """
-        Checks if an Abi with the given 'abi_json' exists using JSONB equality,
-        which normalises key ordering so the lookup is independent of how the
-        caller serialised the dict.
+        Checks if an Abi with the given 'abi_json' exists by matching the
+        sha256 of its JSONB-normalised text form against the indexed
+        `abi_hash` generated column. JSONB normalisation makes the hash
+        stable regardless of key ordering in the input.
 
         :param abi_json: The ABI JSON to check.
         :return: The Abi object if it exists, or None if it doesn't.
         """
-        query = (
-            select(cls)
-            .where(
-                sa_cast(cls.abi_json, JSONB)
-                == sa_cast(literal(json.dumps(abi_json)), JSONB)
+        computed_hash = func.sha256(
+            sa_cast(
+                sa_cast(sa_cast(literal(json.dumps(abi_json)), JSONB), Text),
+                LargeBinary,
             )
-            .limit(1)
         )
+        query = select(cls).where(cls.abi_hash == computed_hash).limit(1)
         result = await db_session.execute(query)
         return result.scalars().first()
 

--- a/app/datasources/db/utils.py
+++ b/app/datasources/db/utils.py
@@ -1,9 +1,0 @@
-import hashlib
-import json
-
-
-def get_md5_abi_hash(abi: list[dict] | dict) -> bytes:
-    json_str = json.dumps(abi, sort_keys=True)
-    md5_hash = hashlib.md5(json_str.encode("utf-8")).hexdigest()
-    abi_hash = md5_hash[-8:]
-    return bytes.fromhex(abi_hash)

--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -10,7 +10,6 @@ from safe_eth.eth.utils import (
     fast_is_checksum_address,
     fast_to_checksum_address,
 )
-from safe_eth.util.util import to_0x_hex_str
 
 from ..config import settings
 from ..services.data_decoder import DecodingAccuracyEnum
@@ -31,21 +30,7 @@ class AbiPublic(CamelModel):
     model_config = ConfigDict(from_attributes=True)
 
     abi_json: list[dict] | dict | None
-    abi_hash: bytes | str
     modified: datetime
-
-    @field_validator("abi_hash")
-    @classmethod
-    def convert_bytes_to_hex(cls, abi_hash: bytes):
-        """
-        Convert bytes to hex
-
-        :param abi_hash:
-        :return:
-        """
-        if isinstance(abi_hash, bytes):
-            return to_0x_hex_str(abi_hash)  # Convert bytes to a hex string
-        return abi_hash
 
 
 class ContractsPublic(CamelModel):

--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -29,8 +29,16 @@ class ProjectPublic(CamelModel):
 class AbiPublic(CamelModel):
     model_config = ConfigDict(from_attributes=True)
 
+    abi_hash: str | None = None
     abi_json: list[dict] | dict | None
     modified: datetime
+
+    @field_validator("abi_hash", mode="before")
+    @classmethod
+    def bytes_to_hex(cls, v: bytes | str | None) -> str | None:
+        if isinstance(v, bytes):
+            return "0x" + v.hex()
+        return v
 
 
 class ContractsPublic(CamelModel):

--- a/app/tests/datasources/db/test_migrations.py
+++ b/app/tests/datasources/db/test_migrations.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import asyncio
 
 from alembic import command
@@ -6,7 +7,7 @@ from hexbytes import HexBytes
 from sqlalchemy import text
 
 from app.datasources.db.database import db_session, db_session_context
-from app.datasources.db.models import Contract
+from app.datasources.db.models import Abi, AbiSource, Contract
 from app.tests.datasources.db.async_db_test_case import AsyncDbTestCase
 
 
@@ -50,3 +51,47 @@ class TestMigrations(AsyncDbTestCase):
         self.assertEqual(await self.get_alembic_version(), tested_version)
         contract = await Contract.get_contract(address=address, chain_id=1)
         self.assertTrue(contract.trusted_for_delegate_call)
+
+    @db_session_context
+    async def test_migration_abi_hash_generated_column(self):
+        tested_version = "a4f3b2c1d8e9"
+        previous_version = "0da35e86b777"
+
+        # At head: abi_hash is a GENERATED ALWAYS AS column — insert an ABI and
+        # verify PostgreSQL populates the hash automatically (sha256 = 32 bytes).
+        source = AbiSource(name="migration_hash_test", url="")
+        await source.create()
+        source_id = source.id
+        abi = Abi(
+            abi_json=[{"type": "function", "name": "transfer"}],
+            relevance=0,
+            source_id=source_id,
+        )
+        await abi.create()
+        await db_session.commit()
+
+        result = await db_session.execute(
+            text("SELECT length(abi_hash) FROM abi LIMIT 1")
+        )
+        await db_session.commit()
+        self.assertEqual(result.scalar_one(), 32)
+
+        # Downgrade: abi_hash becomes a plain nullable bytea column.
+        # Existing rows lose their hash value (NULL after column recreation).
+        await asyncio.to_thread(
+            command.downgrade, self.alembic_config, previous_version
+        )
+        self.assertEqual(await self.get_alembic_version(), previous_version)
+        result = await db_session.execute(text("SELECT abi_hash FROM abi LIMIT 1"))
+        await db_session.commit()
+        self.assertIsNone(result.scalar_one())
+
+        # Upgrade: abi_hash becomes a generated column again.
+        # PostgreSQL recomputes the hash for all existing rows on the ALTER TABLE.
+        await asyncio.to_thread(command.upgrade, self.alembic_config, tested_version)
+        self.assertEqual(await self.get_alembic_version(), tested_version)
+        result = await db_session.execute(
+            text("SELECT length(abi_hash) FROM abi LIMIT 1")
+        )
+        await db_session.commit()
+        self.assertEqual(result.scalar_one(), 32)

--- a/app/tests/datasources/db/test_models.py
+++ b/app/tests/datasources/db/test_models.py
@@ -4,6 +4,7 @@ from typing import cast
 from eth_account import Account
 from hexbytes import HexBytes
 from safe_eth.eth.utils import fast_to_checksum_address
+from sqlalchemy.exc import IntegrityError
 
 from app.datasources.db.database import db_session, db_session_context
 from app.datasources.db.models import Abi, AbiSource, Contract, Project
@@ -77,9 +78,7 @@ class TestModels(AsyncDbTestCase):
         abi_json = {"name": "A Test Project with relevance 10"}
         source = AbiSource(name="local", url="")
         await source.create()
-        abi = Abi(
-            abi_hash=b"A Test Abi", abi_json=abi_json, relevance=10, source_id=source.id
-        )
+        abi = Abi(abi_json=abi_json, relevance=10, source_id=source.id)
         await abi.create()
         contract = Contract(address=b"a", name="A test contract", chain_id=1, abi=abi)
         await contract.create()
@@ -110,11 +109,7 @@ class TestModels(AsyncDbTestCase):
     async def test_abi(self):
         abi_source = AbiSource(name="A Test Source", url="https://test.com")
         abi_source = await abi_source.create()
-        abi = Abi(
-            abi_hash=b"A Test Abi",
-            abi_json={"name": "A Test Project"},
-            source_id=abi_source.id,
-        )
+        abi = Abi(abi_json={"name": "A Test Project"}, source_id=abi_source.id)
         await abi.create()
         result = await abi.get_all()
         self.assertEqual(result[0], abi)
@@ -129,20 +124,10 @@ class TestModels(AsyncDbTestCase):
         ]
         source = AbiSource(name="A Test Source", url="https://test.com")
         await source.create()
-        abi = Abi(
-            abi_hash=abi_jsons[0]["name"].encode(),
-            abi_json=abi_jsons[0],
-            relevance=100,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=abi_jsons[0], relevance=100, source_id=source.id)
         await abi.create()
 
-        last_abi = Abi(
-            abi_hash=abi_jsons[1]["name"].encode(),
-            abi_json=abi_jsons[1],
-            relevance=100,
-            source_id=source.id,
-        )
+        last_abi = Abi(abi_json=abi_jsons[1], relevance=100, source_id=source.id)
         await last_abi.create()
 
         last_inserted = await Abi.get_last_inserted_id()
@@ -158,21 +143,11 @@ class TestModels(AsyncDbTestCase):
         await source.create()
         abi_by_abi_json = await Abi.get_abi(abi_jsons[0])
         self.assertIsNone(abi_by_abi_json)
-        abi = Abi(
-            abi_hash=b"A Test Abi",
-            abi_json=abi_jsons[0],
-            relevance=100,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=abi_jsons[0], relevance=100, source_id=source.id)
         await abi.create()
         abi_by_abi_json = await Abi.get_abi(abi_jsons[0])
         self.assertEqual(abi_by_abi_json, abi)
-        abi = Abi(
-            abi_hash=b"A Test Abi2",
-            abi_json=abi_jsons[1],
-            relevance=10,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=abi_jsons[1], relevance=10, source_id=source.id)
         await abi.create()
         results = abi.get_abis_sorted_by_relevance()
         result = await anext(results)
@@ -192,20 +167,10 @@ class TestModels(AsyncDbTestCase):
         ]
         source = AbiSource(name="A Test Source", url="https://test.com")
         await source.create()
-        abi = Abi(
-            abi_hash=abi_jsons[0]["name"].encode(),
-            abi_json=abi_jsons[0],
-            relevance=100,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=abi_jsons[0], relevance=100, source_id=source.id)
         await abi.create()
 
-        last_abi = Abi(
-            abi_hash=abi_jsons[1]["name"].encode(),
-            abi_json=abi_jsons[1],
-            relevance=100,
-            source_id=source.id,
-        )
+        last_abi = Abi(abi_json=abi_jsons[1], relevance=100, source_id=source.id)
         await last_abi.create()
 
         assert abi.id is not None
@@ -229,11 +194,7 @@ class TestModels(AsyncDbTestCase):
         await abi_source.create()
         result = await abi_source.get_all()
         self.assertEqual(result[0], abi_source)
-        abi = Abi(
-            abi_hash=b"A Test Abi",
-            abi_json={"name": "A Test Project"},
-            source_id=abi_source.id,
-        )
+        abi = Abi(abi_json={"name": "A Test Project"}, source_id=abi_source.id)
         await abi.create()
         result = await abi.get_all()
         self.assertEqual(result[0], abi)
@@ -427,3 +388,46 @@ class TestModels(AsyncDbTestCase):
 
         exists = await Contract.exists_safe_contracts(1, {b"non_existent_address"})
         self.assertFalse(exists)
+
+    @db_session_context
+    async def test_abi_hash_generated_column(self):
+        """abi_hash is a GENERATED ALWAYS AS column — PostgreSQL fills it automatically.
+
+        Verifies that after create():
+        - abi_hash is populated (not None)
+        - abi_hash is exactly 32 bytes (SHA-256 output)
+        - Two ABIs with the same logical content but different key ordering get
+          the same hash (JSONB normalises before hashing)
+        - Two ABIs with different content get different hashes
+        """
+        source = AbiSource(name="hash_test_source", url="")
+        await source.create()
+        source_id = source.id  # capture before any rollback expires the object
+
+        abi_json = [{"type": "function", "name": "transfer"}]
+        abi = Abi(abi_json=abi_json, source_id=source_id)
+        await abi.create()
+
+        self.assertIsNotNone(abi.abi_hash)
+        assert abi.abi_hash is not None  # narrow type for len()
+        self.assertEqual(len(abi.abi_hash), 32)
+        first_hash = abi.abi_hash
+
+        # Same logical content, keys in different order — must produce the same hash
+        # (JSONB normalises key ordering before hashing)
+        abi_json_reordered = [{"name": "transfer", "type": "function"}]
+        abi2 = Abi(abi_json=abi_json_reordered, source_id=source_id)
+        with self.assertRaisesRegex(
+            IntegrityError,
+            r'duplicate key value violates unique constraint "ix_abi_abi_hash"',
+        ):
+            await abi2.create()
+        await db_session.rollback()
+
+        # Different content — different hash
+        abi3 = Abi(
+            abi_json=[{"type": "function", "name": "approve"}], source_id=source_id
+        )
+        await abi3.create()
+        self.assertIsNotNone(abi3.abi_hash)
+        self.assertNotEqual(first_hash, abi3.abi_hash)

--- a/app/tests/datasources/db/test_models.py
+++ b/app/tests/datasources/db/test_models.py
@@ -409,7 +409,7 @@ class TestModels(AsyncDbTestCase):
         await abi.create()
 
         self.assertIsNotNone(abi.abi_hash)
-        assert abi.abi_hash is not None  # narrow type for len()
+        assert abi.abi_hash is not None
         self.assertEqual(len(abi.abi_hash), 32)
         first_hash = abi.abi_hash
 

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -78,7 +78,6 @@ class TestRouterContract(AsyncDbTestCase):
         self.assertEqual(results[0]["name"], "A Test Contracts")
         self.assertEqual(results[0]["address"], address_expected)
         self.assertEqual(results[0]["abi"]["abiJson"], mock_abi_json)
-        self.assertEqual(results[0]["abi"]["abiHash"], "0xb4b61541")
         self.assertEqual(results[0]["abi"]["modified"], datetime_to_str(abi.modified))
         self.assertEqual(results[0]["displayName"], None)
         self.assertEqual(results[0]["chainId"], 1)

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -79,6 +79,8 @@ class TestRouterContract(AsyncDbTestCase):
         self.assertEqual(results[0]["address"], address_expected)
         self.assertEqual(results[0]["abi"]["abiJson"], mock_abi_json)
         self.assertEqual(results[0]["abi"]["modified"], datetime_to_str(abi.modified))
+        assert abi.abi_hash is not None
+        self.assertEqual(results[0]["abi"]["abiHash"], "0x" + abi.abi_hash.hex())
         self.assertEqual(results[0]["displayName"], None)
         self.assertEqual(results[0]["chainId"], 1)
         self.assertEqual(results[0]["project"], None)

--- a/app/tests/routers/test_data_decoder.py
+++ b/app/tests/routers/test_data_decoder.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 from typing import cast
 
 from eth_typing import ABIEvent, ABIFunction
@@ -118,12 +119,7 @@ class TestRouterAbout(AsyncDbTestCase):
         await source.create()
 
         contract_address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-        abi = Abi(
-            abi_hash=b"ExampleABI",
-            abi_json=example_abi,
-            relevance=101,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=example_abi, relevance=101, source_id=source.id)
         await abi.create()
         contract = Contract(
             address=HexBytes(contract_address),
@@ -134,10 +130,7 @@ class TestRouterAbout(AsyncDbTestCase):
         await contract.create()
 
         swapped_abi = Abi(
-            abi_hash=b"SwappedABI",
-            abi_json=example_swapped_abi,
-            relevance=100,
-            source_id=source.id,
+            abi_json=example_swapped_abi, relevance=100, source_id=source.id
         )
         await swapped_abi.create()
         contract = Contract(

--- a/app/tests/services/test_contract_metadata.py
+++ b/app/tests/services/test_contract_metadata.py
@@ -259,7 +259,6 @@ class TestContractMetadataService(AsyncDbTestCase):
         # Should be false if contract has abi_id
         source, _ = await AbiSource.get_or_create("Etherscan", "")
         abi = Abi(
-            abi_hash=b"A Test Abi",
             abi_json=etherscan_metadata_mock.abi,
             relevance=10,
             source_id=source.id,

--- a/app/tests/services/test_data_decoder.py
+++ b/app/tests/services/test_data_decoder.py
@@ -53,60 +53,19 @@ class TestDataDecoderService(AsyncDbTestCase):
 
         # Add Safe Contract Abi and decode it
         for abi in (
+            Abi(abi_json=erc20_contract.abi, relevance=150, source_id=source.id),
+            Abi(abi_json=safe_v1_1_1_contract.abi, relevance=100, source_id=source.id),
+            Abi(abi_json=safe_v1_4_1_contract.abi, relevance=100, source_id=source.id),
+            Abi(abi_json=multisend_contract.abi, relevance=100, source_id=source.id),
+            Abi(abi_json=gnosis_protocol_abi, relevance=50, source_id=source.id),
             Abi(
-                abi_hash=b"ERC20Contract",
-                abi_json=erc20_contract.abi,
-                relevance=150,
-                source_id=source.id,
-            ),
-            Abi(
-                abi_hash=b"SafeContractV1_1_1_ABI",
-                abi_json=safe_v1_1_1_contract.abi,
-                relevance=100,
-                source_id=source.id,
-            ),
-            Abi(
-                abi_hash=b"SafeContractV1_4_1_ABI",
-                abi_json=safe_v1_4_1_contract.abi,
-                relevance=100,
-                source_id=source.id,
-            ),
-            Abi(
-                abi_hash=b"MultiSendContractABI",
-                abi_json=multisend_contract.abi,
-                relevance=100,
-                source_id=source.id,
-            ),
-            Abi(
-                abi_hash=b"GnosisProtocolABI",
-                abi_json=gnosis_protocol_abi,
-                relevance=50,
-                source_id=source.id,
-            ),
-            Abi(
-                abi_hash=b"FleetFactoryDeterministic",
                 abi_json=fleet_factory_deterministic_abi,
                 relevance=50,
                 source_id=source.id,
             ),
-            Abi(
-                abi_hash=b"FleetFactory",
-                abi_json=fleet_factory_abi,
-                relevance=50,
-                source_id=source.id,
-            ),
-            Abi(
-                abi_hash=b"cTokenABI",
-                abi_json=ctoken_abi,
-                relevance=50,
-                source_id=source.id,
-            ),
-            Abi(
-                abi_hash=b"comptrollerABI",
-                abi_json=comptroller_abi,
-                relevance=50,
-                source_id=source.id,
-            ),
+            Abi(abi_json=fleet_factory_abi, relevance=50, source_id=source.id),
+            Abi(abi_json=ctoken_abi, relevance=50, source_id=source.id),
+            Abi(abi_json=comptroller_abi, relevance=50, source_id=source.id),
         ):
             await abi.create()
 
@@ -441,12 +400,7 @@ class TestDataDecoderService(AsyncDbTestCase):
         source = AbiSource(name="local", url="")
         await source.create()
         # Test load a new DbTxDecoder
-        abi = Abi(
-            abi_hash=b"ExampleABI",
-            abi_json=example_abi,
-            relevance=100,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=example_abi, relevance=100, source_id=source.id)
         await abi.create()
         decoder_service = DataDecoderService()
         await decoder_service.init()
@@ -454,12 +408,7 @@ class TestDataDecoderService(AsyncDbTestCase):
         self.assertEqual(fn_name, "buyDroid")
         self.assertEqual(arguments, {"droidId": "4", "numberOfDroids": "10"})
 
-        abi = Abi(
-            abi_hash=b"SwappedABI",
-            abi_json=example_swapped_abi,
-            relevance=100,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=example_swapped_abi, relevance=100, source_id=source.id)
         await abi.create()
         contract = Contract(address=b"c", abi=abi, name="SwappedContract", chain_id=1)
         await contract.create()
@@ -486,19 +435,11 @@ class TestDataDecoderService(AsyncDbTestCase):
 
         # Both ABIs generate the same function selector, but with differently ordered parameter names, so
         # decoding will be different
-        abi = Abi(
-            abi_hash=b"ExampleABI",
-            abi_json=example_abi,
-            relevance=1,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=example_abi, relevance=1, source_id=source.id)
         await abi.create()
 
         abi_reversed = Abi(
-            abi_hash=b"ExampleABIReversed",
-            abi_json=example_swapped_abi,
-            relevance=100,
-            source_id=source.id,
+            abi_json=example_swapped_abi, relevance=100, source_id=source.id
         )
         await abi_reversed.create()
 
@@ -608,10 +549,7 @@ class TestDataDecoderService(AsyncDbTestCase):
         source = AbiSource(name="local", url="")
         await source.create()
         contract_fallback_abi = Abi(
-            abi_hash=b"TupleABI",
-            abi_json=tuple_abi,
-            relevance=100,
-            source_id=source.id,
+            abi_json=tuple_abi, relevance=100, source_id=source.id
         )
         await contract_fallback_abi.create()
 
@@ -657,12 +595,7 @@ class TestDataDecoderService(AsyncDbTestCase):
         # Add a new ABI
         source = AbiSource(name="local", url="")
         await source.create()
-        abi = Abi(
-            abi_hash=b"ExampleABI",
-            abi_json=example_abi,
-            relevance=1,
-            source_id=source.id,
-        )
+        abi = Abi(abi_json=example_abi, relevance=1, source_id=source.id)
         await abi.create()
         len_previous_selectors = len(decoder_service.fn_selectors_with_abis)
         self.assertEqual(await decoder_service.load_new_abis(), 1)

--- a/migrations/versions/a4f3b2c1d8e9_abi_hash_generated_sha256.py
+++ b/migrations/versions/a4f3b2c1d8e9_abi_hash_generated_sha256.py
@@ -1,0 +1,40 @@
+"""abi_hash_generated_sha256
+
+Replace the manually-computed 4-byte MD5 abi_hash column with a PostgreSQL
+GENERATED ALWAYS AS column that stores sha256(abi_json::jsonb::text::bytea).
+JSONB normalises key ordering, making the hash stable regardless of insertion
+order. The unique constraint continues to enforce ABI deduplication.
+
+Revision ID: a4f3b2c1d8e9
+Revises: 0da35e86b777
+Create Date: 2026-04-16
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a4f3b2c1d8e9"
+down_revision: str | None = "0da35e86b777"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX ix_abi_abi_hash")
+    op.execute("ALTER TABLE abi DROP COLUMN abi_hash")
+    op.execute(
+        "ALTER TABLE abi ADD COLUMN abi_hash bytea"
+        " GENERATED ALWAYS AS (sha256(abi_json::jsonb::text::bytea)) STORED"
+    )
+    op.execute("CREATE UNIQUE INDEX ix_abi_abi_hash ON abi (abi_hash)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX ix_abi_abi_hash")
+    op.execute("ALTER TABLE abi DROP COLUMN abi_hash")
+    op.execute("ALTER TABLE abi ADD COLUMN abi_hash bytea")
+    op.execute("CREATE UNIQUE INDEX ix_abi_abi_hash ON abi (abi_hash)")
+    # Note: downgrade leaves abi_hash NULL for all existing rows.
+    # Full reversal would require recomputing get_md5_abi_hash per row in Python.


### PR DESCRIPTION
The old `get_md5_abi_hash` truncated MD5 to 4 bytes, giving ~50% collision probability at 65k rows. The new `abi_hash` column is `GENERATED ALWAYS AS (sha256(abi_json::jsonb::text::bytea)) STORED` so PostgreSQL owns both the computation and the uniqueness guarantee. `JSONB` normalisation makes the hash stable regardless of key insertion order.

Python no longer computes or stores the hash; `get_or_create_abi` uses the `IntegrityError` try/catch pattern for concurrent-safe upserts, and get_abi uses a `JSONB` equality query for key-order-independent lookup.

Fixes PLA-1301