### PR TITLE
Use implementation ABI when decoding proxy calls

### DIFF
--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -206,6 +206,27 @@ class DataDecoderService:
             return await self._generate_selectors_with_abis_from_abi(abi)
         return None
 
+    @alru_cache(maxsize=2048)
+    async def get_contract_implementation_abi_selectors_with_functions(
+        self, address: Address, chain_id: int | None
+    ) -> dict[bytes, ABIFunction] | None:
+        """
+        :param address: Proxy contract address
+        :param chain_id: Chain for the contract
+        :return: Dictionary of function selectors with `ABIFunction` for the
+            implementation contract if found, `None` otherwise.
+        """
+        if chain_id is None:
+            return None
+
+        contract = await Contract.get_contract(HexBytes(address), chain_id)
+        if not contract or not contract.implementation:
+            return None
+
+        return await self.get_contract_abi_selectors_with_functions(
+            Address(contract.implementation), chain_id
+        )
+
     async def get_abi_function(
         self, data: bytes, address: Address | None = None, chain_id: int | None = None
     ) -> ABIFunction | None:
@@ -232,6 +253,16 @@ class DataDecoderService:
                     # If the selector is available in the abi specific for the address we will use that one
                     # Otherwise we fall back to the general abi that matches the selector
                     return contract_selectors_with_abis[selector]
+                implementation_selectors_with_abis = (
+                    await self.get_contract_implementation_abi_selectors_with_functions(
+                        address, chain_id
+                    )
+                )
+                if (
+                    implementation_selectors_with_abis
+                    and selector in implementation_selectors_with_abis
+                ):
+                    return implementation_selectors_with_abis[selector]
             return self.fn_selectors_with_abis[selector]
         return None
 

--- a/app/tests/services/test_data_decoder.py
+++ b/app/tests/services/test_data_decoder.py
@@ -590,6 +590,107 @@ class TestDataDecoderService(AsyncDbTestCase):
         self.assertEqual(accuracy, DecodingAccuracyEnum.ONLY_FUNCTION_MATCH)
 
     @db_session_context
+    async def test_decode_proxy_using_implementation_abi(self):
+        proxy_address = Address(HexBytes("0x1000000000000000000000000000000000000001"))
+        implementation_address = Address(
+            HexBytes("0x2000000000000000000000000000000000000002")
+        )
+        source = AbiSource(name="local", url="")
+        await source.create()
+
+        proxy_abi = [
+            {
+                "type": "function",
+                "name": "implementation",
+                "inputs": [],
+                "outputs": [{"name": "", "type": "address"}],
+                "stateMutability": "view",
+            }
+        ]
+        implementation_abi = [
+            {
+                "type": "function",
+                "name": "mint",
+                "inputs": [
+                    {"name": "depositAddr", "type": "address"},
+                    {"name": "amount", "type": "uint256"},
+                    {"name": "validUntil", "type": "uint256"},
+                ],
+                "outputs": [],
+                "stateMutability": "nonpayable",
+            }
+        ]
+        generic_mint_abi = [
+            {
+                "type": "function",
+                "name": "mint",
+                "inputs": [
+                    {"name": "to", "type": "address"},
+                    {"name": "value", "type": "uint256"},
+                    {"name": "deadline", "type": "uint256"},
+                ],
+                "outputs": [],
+                "stateMutability": "nonpayable",
+            }
+        ]
+        proxy_abi_model = await Abi(
+            abi_hash=b"ProxyABI",
+            abi_json=proxy_abi,
+            relevance=1,
+            source_id=source.id,
+        ).create()
+        implementation_abi_model = await Abi(
+            abi_hash=b"ImplementationABI",
+            abi_json=implementation_abi,
+            relevance=1,
+            source_id=source.id,
+        ).create()
+        await Abi(
+            abi_hash=b"GenericMintABI",
+            abi_json=generic_mint_abi,
+            relevance=100,
+            source_id=source.id,
+        ).create()
+        await Contract(
+            address=proxy_address,
+            abi=proxy_abi_model,
+            implementation=implementation_address,
+            name="ProxyContract",
+            chain_id=11155111,
+        ).create()
+        await Contract(
+            address=implementation_address,
+            abi=implementation_abi_model,
+            name="ImplementationContract",
+            chain_id=11155111,
+        ).create()
+
+        data = (
+            Web3()
+            .eth.contract(abi=implementation_abi)
+            .functions.mint(NULL_ADDRESS, 1, 2)
+            .build_transaction(
+                get_empty_tx_params() | {"to": NULL_ADDRESS, "chainId": 11155111}
+            )["data"]
+        )
+
+        decoder_service = DataDecoderService()
+        await decoder_service.init()
+
+        fn_name, arguments = await decoder_service.decode_transaction(
+            data, address=proxy_address, chain_id=11155111
+        )
+        self.assertEqual(fn_name, "mint")
+        self.assertEqual(
+            arguments,
+            {
+                "depositAddr": NULL_ADDRESS,
+                "amount": "1",
+                "validUntil": "2",
+            },
+        )
+
+    @db_session_context
     async def test_decode_tuples(self):
         """
         Test tuple parameters are decoded as expected


### PR DESCRIPTION
## What

Fixes #242 by letting the decoder use the stored implementation contract ABI when a proxy contract ABI does not contain the incoming selector.

The existing metadata flow already persists `Contract.implementation` and queues metadata retrieval for that implementation. This change wires that data into `DataDecoderService.get_abi_function`: proxy ABI selectors are still preferred, then implementation ABI selectors are checked, then the existing global selector fallback remains unchanged.

## Why

For proxy contracts like the Sepolia example in #242, the proxy address can have metadata but the callable application selector is only present on the implementation ABI. Without this, decoding can fall through to a generic selector match and produce misleading argument names.

## Tests

- `uv run --with ruff ruff check app/services/data_decoder.py app/tests/services/test_data_decoder.py`
- `uv run --with ruff ruff format --check app/services/data_decoder.py app/tests/services/test_data_decoder.py`
- `ENV_FILE=.env.test DB_NAME=testdb uv run mypy app/services/data_decoder.py app/tests/services/test_data_decoder.py`
- In-process decoder sanity check with a mocked proxy -> implementation lookup, including a misleading generic `mint(address,uint256,uint256)` fallback ABI

I also attempted the DB-backed regression directly:

- `ENV_FILE=.env.test DB_NAME=testdb uv run pytest app/tests/services/test_data_decoder.py::TestDataDecoderService::test_decode_proxy_using_implementation_abi -q`

That is blocked in my local environment because this repo expects local Postgres on `localhost:5432`, and Docker is not available here to start the test services.
