### PR TITLE
Make DB pool max_overflow configurable and enable pool_pre_ping

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 """
 Base settings file for FastApi application.
 """
@@ -25,6 +26,8 @@ class Settings(BaseSettings):
     DATABASE_URL: str = "psql://postgres:"
     DATABASE_POOL_CLASS: str = "AsyncAdaptedQueuePool"
     DATABASE_POOL_SIZE: int = 10
+    # Extra connections allowed above pool_size
+    DATABASE_POOL_MAX_OVERFLOW: int = 10
     RABBITMQ_AMQP_URL: str = "amqp://guest:guest@"
     RABBITMQ_AMQP_EXCHANGE: str = "safe-transaction-service-events"
     RABBITMQ_DECODER_EVENTS_QUEUE_NAME: str = "safe-decoder-service"

--- a/app/datasources/db/database.py
+++ b/app/datasources/db/database.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import logging
 import uuid
 from collections.abc import Generator
@@ -43,6 +44,8 @@ def get_engine() -> AsyncEngine:
             future=True,
             poolclass=pool_classes.get(settings.DATABASE_POOL_CLASS),
             pool_size=settings.DATABASE_POOL_SIZE,
+            max_overflow=settings.DATABASE_POOL_MAX_OVERFLOW,
+            pool_pre_ping=True,
         )
 
 


### PR DESCRIPTION
Make DB pool max_overflow configurable and enable pool_pre_ping

## What

- Add a `DATABASE_POOL_MAX_OVERFLOW` setting and pass it to `create_async_engine` as `max_overflow`.
- Enable `pool_pre_ping=True` so dead/stale pooled connections are detected on checkout.

## Why

Production hit `asyncpg.exceptions.TooManyConnectionsError: remaining connection slots are reserved for roles with privileges of the "pg_use_reserved_connections" role` (2026-06-09).

The engine used `pool_size=10` with no explicit `max_overflow`, so SQLAlchemy's default overflow of 10 applied — each worker could open up to 20 connections. `get_engine()` is cached per process, so total usage scales as `workers × pods × per-worker ceiling`, which exhausted Postgres connection slots.

Exposing `max_overflow` via config makes the per-worker connection ceiling explicit and tunable per environment, so total usage can be kept under Postgres `max_connections`. `pool_pre_ping` avoids handing out connections the server already closed.

## Notes

- Default `DATABASE_POOL_MAX_OVERFLOW` is 10 (preserves current behaviour); lower it in deployment to bound total connections.
- Operational tuning of deployed values is tracked in PLA-1617.

Closes PLA-1617