### PR TITLE
Fix connections left idle in transaction exhausting Postgres slots

### DIFF
--- a/app/commands/register_commands.py
+++ b/app/commands/register_commands.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import asyncio
 import inspect
 from collections.abc import Callable
@@ -10,7 +11,7 @@ from app.commands.download_contract import download_contract_command
 from app.commands.safe_contracts import (
     setup_safe_contracts,
 )
-from app.datasources.db.database import db_session, set_database_session_context
+from app.datasources.db.database import with_db_session_context
 
 
 def async_command(func: Callable) -> Callable:
@@ -27,11 +28,8 @@ def async_command(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any):
             async def run_with_context():
-                with set_database_session_context():
-                    try:
-                        return await func(*args, **kwargs)
-                    finally:
-                        await db_session.remove()
+                async with with_db_session_context():
+                    return await func(*args, **kwargs)
 
             return asyncio.run(run_with_context())
 

--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
     DATABASE_POOL_SIZE: int = 10
     # Extra connections allowed above pool_size
     DATABASE_POOL_MAX_OVERFLOW: int = 10
+    # Force-closes transactions left idle so leaked connections are reclaimed
+    DATABASE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_MS: int = 30_000
     RABBITMQ_AMQP_URL: str = "amqp://guest:guest@"
     RABBITMQ_AMQP_EXCHANGE: str = "safe-transaction-service-events"
     RABBITMQ_DECODER_EVENTS_QUEUE_NAME: str = "safe-decoder-service"

--- a/app/datasources/db/database.py
+++ b/app/datasources/db/database.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 import logging
 import uuid
-from collections.abc import Generator
-from contextlib import contextmanager
+from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from functools import cache, wraps
 
@@ -46,6 +46,13 @@ def get_engine() -> AsyncEngine:
             pool_size=settings.DATABASE_POOL_SIZE,
             max_overflow=settings.DATABASE_POOL_MAX_OVERFLOW,
             pool_pre_ping=True,
+            connect_args={
+                "server_settings": {
+                    "idle_in_transaction_session_timeout": str(
+                        settings.DATABASE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_MS
+                    )
+                }
+            },
         )
 
 
@@ -80,23 +87,42 @@ def _get_database_session_context() -> str:
     return _db_session_context.get()
 
 
+@asynccontextmanager
+async def with_db_session_context(
+    session_id: str | None = None,
+) -> AsyncGenerator[None]:
+    """
+    Async context manager that opens a database session scope and guarantees the
+    scoped session (and its connection) is released on exit via `db_session.remove()`.
+
+    Use it to bound a unit of database work so the connection is returned to the
+    pool as soon as that work is done, instead of being held until the end of the
+    surrounding request/task.
+
+    :param session_id:
+    :return:
+    """
+    with set_database_session_context(session_id):
+        try:
+            yield
+        finally:
+            logger.debug(
+                "Removing session context: %s", _get_database_session_context()
+            )
+            await db_session.remove()
+
+
 def db_session_context(func):
     """
-    Wrap the decorated function in the `set_database_session_context` context.
+    Wrap the decorated function in the `with_db_session_context` context.
     Decorated function will share the same database session.
     Remove the session at the end of the context.
     """
 
     @wraps(func)
     async def wrapper(*args, **kwargs):
-        with set_database_session_context():
-            try:
-                return await func(*args, **kwargs)
-            finally:
-                logger.debug(
-                    "Removing session context: %s", _get_database_session_context()
-                )
-                await db_session.remove()
+        async with with_db_session_context():
+            return await func(*args, **kwargs)
 
     return wrapper
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,10 +12,7 @@ from starlette.responses import Response
 from app.loggers.safe_logger import HttpRequestLog, HttpResponseLog
 
 from . import VERSION
-from .datasources.db.database import (
-    db_session,
-    set_database_session_context,
-)
+from .datasources.db.database import with_db_session_context
 from .datasources.queue.exceptions import QueueProviderUnableToConnectException
 from .datasources.queue.queue_provider import QueueProvider
 from .routers import about, admin, contracts, data_decoder, default
@@ -55,7 +52,7 @@ async def lifespan(app: FastAPI):
             )
             logger.debug("Created task to consume elements from Queue Provider")
 
-        with set_database_session_context("InitializeDataDecoderServiceOnStartup"):
+        async with with_db_session_context("InitializeDataDecoderServiceOnStartup"):
             # Load hardcoded ABIs in database
             await abi_service.load_local_abis_in_database()
             # Initializes DataDecoderService
@@ -141,39 +138,36 @@ async def http_request_middleware(request: Request, call_next):
     :return:
     """
     start_time = datetime.datetime.now(datetime.UTC)
-    with set_database_session_context():
-        response: Response | None = None
-        try:
+    response: Response | None = None
+    try:
+        async with with_db_session_context():
             response = await call_next(request)
-        finally:
-            await db_session.remove()
-            # Log request
-            try:
-                end_time = datetime.datetime.now(datetime.UTC)
-                total_time = (
-                    end_time - start_time
-                ).total_seconds() * 1000  # time in ms
-                route = request.scope.get("route")
-                http_request = HttpRequestLog(
-                    url=str(request.url),
-                    route=route.path if route else None,
-                    method=request.method,
-                    startTime=start_time,
-                )
-                status_code = response.status_code if response else 500
-                http_response = HttpResponseLog(
-                    status=status_code,
-                    endTime=end_time,
-                    totalTime=int(total_time),
-                )
-                logger.info(
-                    "Http request",
-                    extra={
-                        "http_response": http_response.model_dump(),
-                        "http_request": http_request.model_dump(),
-                    },
-                )
-            except Exception as e:
-                logger.error(f"Validation log error {e}")
+    finally:
+        # Log request
+        try:
+            end_time = datetime.datetime.now(datetime.UTC)
+            total_time = (end_time - start_time).total_seconds() * 1000  # time in ms
+            route = request.scope.get("route")
+            http_request = HttpRequestLog(
+                url=str(request.url),
+                route=route.path if route else None,
+                method=request.method,
+                startTime=start_time,
+            )
+            status_code = response.status_code if response else 500
+            http_response = HttpResponseLog(
+                status=status_code,
+                endTime=end_time,
+                totalTime=int(total_time),
+            )
+            logger.info(
+                "Http request",
+                extra={
+                    "http_response": http_response.model_dump(),
+                    "http_request": http_request.model_dump(),
+                },
+            )
+        except Exception as e:
+            logger.error(f"Validation log error {e}")
 
     return response

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -10,7 +10,7 @@ from safe_eth.util.util import to_0x_hex_str
 
 from app.config import settings
 from app.datasources.cache.redis import del_contract_cache, get_redis
-from app.datasources.db.database import db_session_context
+from app.datasources.db.database import db_session_context, with_db_session_context
 from app.datasources.db.models import Contract
 from app.loggers.safe_logger import logging_task_context
 from app.services.contract_metadata_service import get_contract_metadata_service
@@ -45,13 +45,15 @@ async def get_contract_metadata_task(
 ):
     with logging_task_context(CurrentMessage.get_current_message()):
         contract_metadata_service = get_contract_metadata_service()
-        # Just try the first time, following retries should be scheduled
-        if (
-            skip_attempt_download
-            or await contract_metadata_service.should_attempt_download(
-                address, chain_id, 0
+        async with with_db_session_context():
+            # Just try the first time, following retries should be scheduled
+            should_download = (
+                skip_attempt_download
+                or await contract_metadata_service.should_attempt_download(
+                    address, chain_id, 0
+                )
             )
-        ):
+        if should_download:
             logger.info("Downloading contract metadata")
             contract_metadata = await contract_metadata_service.get_contract_metadata(
                 fast_to_checksum_address(address), chain_id


### PR DESCRIPTION

## Problem

Production hit `asyncpg.exceptions.TooManyConnectionsError`. RDS showed connections opened but not closed, parked in state `idle in transaction`, accumulating until Postgres `max_connections` (200) was exceeded.

Even if this is not the root cause, we want to minimize and optimize our connections

## Changes

- **Release the read transaction before external I/O** (`app/workers/tasks.py`): `should_attempt_download` now runs inside its own `with_db_session_context()` scope, so its session/connection is returned to the pool *before* the download starts, instead of being held `idle in transaction` during it.
- **`with_db_session_context` async context manager** (`app/datasources/db/database.py`): holds the single canonical session-scope lifecycle (set context → `yield` → `await db_session.remove()`). The `db_session_context` decorator and the startup ABI initialization now reuse it.
- **Fix startup session leak** (`app/main.py`): the `InitializeDataDecoderServiceOnStartup` block previously opened a session scope but never released it, leaving one connection `idle in transaction` for the whole process lifetime. It now uses `with_db_session_context`.
- **Backstop** (`app/datasources/db/database.py`, `app/config.py`): set Postgres `idle_in_transaction_session_timeout` per connection (configurable via `DATABASE_IDLE_IN_TRANSACTION_SESSION_TIMEOUT_MS`, default 30000 ms, `0` disables) so any future leaked transaction is force-reclaimed server-side.

## Notes

- Global `AUTOCOMMIT` (which would prevent reads from holding any transaction service-wide) was evaluated and rejected: the service uses `db_session.stream()` server-side cursors, which require an open transaction — AUTOCOMMIT raises `NoActiveSQLTransactionError`. The targeted release + server-side timeout cover the known leak paths without that constraint.
- The HTTP request middleware keeps its existing `set_database_session_context` + `db_session.remove()` form because its `finally` also performs request logging; requests are short-lived so they release promptly.
- Possible follow-up (not tracked yet): collapse `db_session_context` and `with_db_session_context` into a single `asynccontextmanager` usable both as `async with …()` and `@…()` (Python 3.10+), which would touch ~60 `@db_session_context()` call sites.

Closes PLA-1624