### PR TITLE
Fix small decoder bug

### DIFF
--- a/app/datasources/cache/redis.py
+++ b/app/datasources/cache/redis.py
@@ -60,7 +60,7 @@ def get_field_key(kwargs: dict) -> str:
     request = kwargs.get("request")
     url_path = ""
     if request:
-        url_path = str(get_proxy_aware_url(request)) if request else ""
+        url_path = str(get_proxy_aware_url(request))
 
     # Add query parameters as part of key field except the request.
     cacheable_kwargs = {

--- a/app/services/contract_metadata_service.py
+++ b/app/services/contract_metadata_service.py
@@ -173,7 +173,7 @@ class ContractMetadataService:
 
         if contract_metadata.metadata:
             if not contract_metadata.source:
-                logging.error(
+                logger.error(
                     "Cannot store ABI for %s: metadata present but source is missing",
                     contract_metadata.address,
                 )
@@ -183,7 +183,7 @@ class ContractMetadataService:
 
             source = await AbiSource.get_abi_source(name=contract_metadata.source.value)
             if source is None:
-                logging.error(
+                logger.error(
                     "Abi source %s does not exist", contract_metadata.source.value
                 )
                 contract.fetch_retries += 1
@@ -191,7 +191,7 @@ class ContractMetadataService:
                 return False
 
             if not contract_metadata.metadata.abi:
-                logging.error(
+                logger.error(
                     "Cannot store ABI for %s: ABI is empty or null",
                     contract_metadata.address,
                 )


### PR DESCRIPTION
- Route process_contract_metadata error logs through the module logger instead of the root logging logger, matching the rest of the module so records carry the module name.
- Remove an unreachable ternary branch in redis get_field_key (the request else "" arm sat inside an if request block).