### PR TITLE
Fix display-name whitespace and add @classmethod to validator

### DIFF
--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -94,6 +94,7 @@ class DataDecoderInput(CamelModel):
     )
 
     @field_validator("to")
+    @classmethod
     def validate_checksum_address(cls, value):
         if value and not fast_is_checksum_address(value):
             raise ValueError("Address is not checksummed")

--- a/app/services/safe_contracts_service.py
+++ b/app/services/safe_contracts_service.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import logging
 from functools import cache
 
@@ -40,7 +41,7 @@ class SafeContractsService:
         :param version:
         :return: display_name
         """
-        contract_name = contract_name.replace("Gnosis", "")
+        contract_name = contract_name.replace("Gnosis", "").strip()
         if "safe" not in contract_name.lower():
             return f"Safe: {contract_name} {version}"
         else:


### PR DESCRIPTION
## What

Two small, low-risk fixes surfaced during a code review:

- **`safe_contracts_service`** — `_generate_safe_contract_display_name` removes the `"Gnosis"` prefix but kept any leftover whitespace, so a spaced name (e.g. `"Gnosis Safe"`) produced a display name with a leading space (`" Safe 1.3.0"`). Added `.strip()`. No-op for all current concatenated names (`GnosisSafe`, `GnosisMultiSend`, …), so existing behavior and tests are unchanged.
- **`models`** — added `@classmethod` to the `to` field validator, matching the other validators in the file and the Pydantic v2 convention. Pydantic already passed `cls`; this just makes it explicit.

The file's missing `SPDX-License-Identifier` header was also added automatically by the `insert-license` pre-commit hook.

## Why

Minor consistency / correctness hardening with no behavior change for current inputs.

