### PR TITLE
Pipeline cache write into a single Redis round-trip

### DIFF
--- a/app/datasources/cache/redis.py
+++ b/app/datasources/cache/redis.py
@@ -108,12 +108,14 @@ def cache_response(
             # Store the response in cache for later
             # Force validation to trigger field validators that convert bytes
             validated_response = model.model_validate(response)
-            await redis.hset(  # type: ignore[misc]
-                hash_key, field_key, validated_response.model_dump_json(by_alias=True)
-            )
-            # Set expiration just if is not configured
-            if await redis.ttl(hash_key) == -1:
-                await redis.expire(hash_key, expire)
+            async with redis.pipeline(transaction=False) as pipe:
+                pipe.hset(
+                    hash_key,
+                    field_key,
+                    validated_response.model_dump_json(by_alias=True),
+                )
+                pipe.expire(hash_key, expire, nx=True)
+                await pipe.execute()
 
             return response
 

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -3,7 +3,11 @@ from fastapi.testclient import TestClient
 from hexbytes import HexBytes
 
 from ...config import settings
-from ...datasources.cache.redis import del_contract_cache
+from ...datasources.cache.redis import (
+    del_contract_cache,
+    get_key_for_contract,
+    get_redis,
+)
 from ...datasources.db.database import db_session_context
 from ...datasources.db.models import Abi, AbiSource, Contract
 from ...main import app
@@ -29,6 +33,21 @@ class TestRouterContract(AsyncDbTestCase):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertEqual(response_json["count"], 0)
+
+        # The cached write must set a TTL on the contract hash
+        redis = get_redis()
+        hash_key = get_key_for_contract(address_expected)
+        self.assertGreater(await redis.ttl(hash_key), 0)
+
+        # Lower the TTL, then trigger a write to a different field (different
+        # query params). The TTL must not be extended, as the expiration is set
+        # with `nx` and anchored to the first write.
+        await redis.expire(hash_key, 5)
+        response = self.client.get(
+            f"/api/v1/contracts/{address_expected}?chain_ids=5",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertLessEqual(await redis.ttl(hash_key), 5)
 
         address = HexBytes(address_expected)
         contract = Contract(

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -23,7 +23,9 @@ class TestRouterContract(AsyncDbTestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = TestClient(app)
-
+      async def asyncSetUp(self):
+          await super().asyncSetUp()
+          await get_redis().flushdb()
     @db_session_context
     async def test_view_contracts(self):
         address_expected = "0x6eEF70Da339a98102a642969B3956DEa71A1096e"

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -54,7 +54,6 @@ class TestRouterContract(AsyncDbTestCase):
         ttl = await redis.ttl(hash_key)
         self.assertGreater(ttl, 0)
         self.assertLessEqual(ttl, 5)
-        self.assertLessEqual(await redis.ttl(hash_key), 5)
 
         address = HexBytes(address_expected)
         contract = Contract(

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -49,6 +49,9 @@ class TestRouterContract(AsyncDbTestCase):
             f"/api/v1/contracts/{address_expected}?chain_ids=5",
         )
         self.assertEqual(response.status_code, 200)
+        ttl = await redis.ttl(hash_key)
+        self.assertGreater(ttl, 0)
+        self.assertLessEqual(ttl, 5)
         self.assertLessEqual(await redis.ttl(hash_key), 5)
 
         address = HexBytes(address_expected)

--- a/app/tests/routers/test_contracts.py
+++ b/app/tests/routers/test_contracts.py
@@ -23,9 +23,11 @@ class TestRouterContract(AsyncDbTestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = TestClient(app)
-      async def asyncSetUp(self):
-          await super().asyncSetUp()
-          await get_redis().flushdb()
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        await get_redis().flushdb()
+
     @db_session_context
     async def test_view_contracts(self):
         address_expected = "0x6eEF70Da339a98102a642969B3956DEa71A1096e"


### PR DESCRIPTION
Pipeline cache write into a single Redis round-trip

## What

The cache write path in `cache_response` did 3 sequential Redis round-trips on a cache miss: `hset`, then `ttl`, then a conditional `expire`. This pipes them into a single round-trip.

The `ttl == -1` check existed to set the expiration only on the first write, so adding new fields to the hash later doesn't extend the whole hash TTL. We keep that exact behavior by using `EXPIRE ... NX` (set TTL only if none exists) instead of reading the TTL first. Since `expire(nx=True)` no longer depends on a prior result, it goes in the same pipeline as `hset`.

Result: 3 round-trips down to 1, same semantics.

## Notes

- `EXPIRE ... NX` needs Redis server >= 7.0 and redis-py >= 4.4. We run redis-py 7.4.0 and server 8.x.
- `transaction=False` is used because we want command batching, not atomicity.

## Tests

Extended `test_view_contracts` to cover the TTL behavior, which had no coverage before:
- asserts the cached write sets a TTL on the hash
- lowers the TTL, triggers a write to a different field, and asserts the TTL is not extended (proves the `nx` anchoring)

Verified the new assertion fails without `nx` (TTL resets to 60) and passes with it.