### PR TITLE
fix: scope data-decoder endpoint DB access to its own session context

### DIFF
--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -363,9 +363,10 @@ class DataDecoderService:
         data_str = data if isinstance(data, str) else to_0x_hex_str(data)
         try:
             logger.debug("Decoding data %s", data_str)
-            fn_name, parameters = await self.decode_transaction_with_types(
-                data, address=address, chain_id=chain_id
-            )
+            async with transactional_session_context():
+                fn_name, parameters = await self.decode_transaction_with_types(
+                    data, address=address, chain_id=chain_id
+                )
             decoded: DataDecoded = {"method": fn_name, "parameters": parameters}
             logger.debug("Decoded data %s into %s", data_str, decoded)
             return decoded
@@ -492,12 +493,13 @@ class DataDecoderService:
         if selector not in self.fn_selectors_with_abis:
             return DecodingAccuracyEnum.NO_MATCH
         if address is not None:
-            if chain_id is not None and await self.get_contract_abi(
-                address, chain_id=chain_id
-            ):
-                return DecodingAccuracyEnum.FULL_MATCH
-            if await self.get_contract_abi(address, None):
-                return DecodingAccuracyEnum.PARTIAL_MATCH
+            async with transactional_session_context():
+                if chain_id is not None and await self.get_contract_abi(
+                    address, chain_id=chain_id
+                ):
+                    return DecodingAccuracyEnum.FULL_MATCH
+                if await self.get_contract_abi(address, None):
+                    return DecodingAccuracyEnum.PARTIAL_MATCH
         return DecodingAccuracyEnum.ONLY_FUNCTION_MATCH
 
     async def add_abi(self, abi: ABI) -> bool:

--- a/app/tests/routers/test_data_decoder.py
+++ b/app/tests/routers/test_data_decoder.py
@@ -10,7 +10,7 @@ from safe_eth.util.util import to_0x_hex_str
 from web3 import Web3
 
 from ...datasources.abis.gnosis_protocol import cowswap_settlement_v2_abi
-from ...datasources.db.database import db_session_context
+from ...datasources.db.database import db_session_context, transactional_session_context
 from ...datasources.db.models import Abi, AbiSource, Contract
 from ...main import app
 from ...services.abis import AbiService
@@ -120,33 +120,34 @@ class TestRouterAbout(AsyncDbTestCase):
             },
         )
 
-    @db_session_context
     async def test_view_data_decoder_with_chain_id(self):
-        source = AbiSource(name="local", url="")
-        await source.create()
-
+        # No outer context: the endpoint must scope its own session
         contract_address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-        abi = Abi(abi_json=example_abi, relevance=101, source_id=source.id)
-        await abi.create()
-        contract = Contract(
-            address=HexBytes(contract_address),
-            abi=abi,
-            name="SwappedContract",
-            chain_id=1,
-        )
-        await contract.create()
+        async with transactional_session_context():
+            source = AbiSource(name="local", url="")
+            await source.create()
 
-        swapped_abi = Abi(
-            abi_json=example_swapped_abi, relevance=100, source_id=source.id
-        )
-        await swapped_abi.create()
-        contract = Contract(
-            address=HexBytes(contract_address),
-            abi=swapped_abi,
-            name="SwappedContract",
-            chain_id=2,
-        )
-        await contract.create()
+            abi = Abi(abi_json=example_abi, relevance=101, source_id=source.id)
+            await abi.create()
+            contract = Contract(
+                address=HexBytes(contract_address),
+                abi=abi,
+                name="SwappedContract",
+                chain_id=1,
+            )
+            await contract.create()
+
+            swapped_abi = Abi(
+                abi_json=example_swapped_abi, relevance=100, source_id=source.id
+            )
+            await swapped_abi.create()
+            contract = Contract(
+                address=HexBytes(contract_address),
+                abi=swapped_abi,
+                name="SwappedContract",
+                chain_id=2,
+            )
+            await contract.create()
 
         example_data = (
             Web3()


### PR DESCRIPTION

- Related with https://github.com/safe-global/safe-decoder-service/pull/301