### PR TITLE
fix: handle undecodable MultiSend data in event processing

### DIFF
--- a/app/services/events.py
+++ b/app/services/events.py
@@ -2,6 +2,7 @@
 import json
 import logging
 
+from eth_abi.exceptions import DecodingError
 from eth_typing import ChecksumAddress, HexStr
 from hexbytes import HexBytes
 from safe_eth.eth.constants import NULL_ADDRESS
@@ -28,10 +29,14 @@ class EventsService:
         """
         if not data:
             return set()
-        return {
-            multisend_tx.to
-            for multisend_tx in MultiSend.from_transaction_data(HexBytes(data))
-        }
+        try:
+            return {
+                multisend_tx.to
+                for multisend_tx in MultiSend.from_transaction_data(HexBytes(data))
+            }
+        except (ValueError, DecodingError, ArithmeticError) as exc:
+            logger.warning("Cannot decode MultiSend from data %s: %s", data, exc)
+            return set()
 
     async def process_event(self, message: str) -> None:
         """


### PR DESCRIPTION
`get_contracts_from_data` assumed the calldata of every `EXECUTED_MULTISIG_TRANSACTION` was a `multiSend` call. `MultiSend.from_transaction_data` only catches `ValueError`, so when the data starts with the multiSend selector (`0x8d80ff0a`) but its body isn't a valid argument (truncated, corrupt, or a selector collision), `eth_abi` raised `DecodingError`/`OverflowError` and crashed the queue consumer (`InsufficientDataBytes` in staging). Now we catch `(ValueError, DecodingError, ArithmeticError)`, log a warning and return an empty set; the event is still processed via its `to` address.

