### PR TITLE
chore: optimize dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,66 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 10
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 7
+      exclude:
+        - "safe-eth-py"
+    groups:
+      eth:
+        patterns:
+          - "safe-eth-py"
+          - "web3"
+          - "eth-*"
+        update-types:
+          - minor
+          - patch
+      fastapi:
+        patterns:
+          - "fastapi*"
+          - "pydantic*"
+          - "uvicorn*"
+          - "starlette*"
+        update-types:
+          - minor
+          - patch
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: "/docker/web"
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What

Optimize `.github/dependabot.yml` following GitHub's [PR-creation recommendations](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates), in line with `safe-fee-service` (#130) and `safe-transaction-service`, adapted to this repo's Python/`uv` stack.

## Changes

- **Cooldown + grouping for `github-actions` and `docker`** — grouped into a single PR each with a 7-day cooldown instead of one PR per day-zero bump.
- **Per-semver cooldown for `uv`** — `semver-major-days: 30 / semver-minor-days: 7 / semver-patch-days: 7`. The 7-day floor matches the existing `exclude-newer = "7 days"` in `pyproject.toml`; a shorter patch cooldown would let dependabot propose releases that `uv lock` then refuses to resolve.
- **`cooldown.exclude: safe-eth-py`** — mirrors the `exclude-newer-package = { safe-eth-py = false }` exemption so the core lib still gets fast updates instead of being held back 7 days.
- **`uv` groups + catch-all** — `eth` (`safe-eth-py`, `web3`, `eth-*`) and `fastapi` (`fastapi*`, `pydantic*`, `uvicorn*`, `starlette*`) families, plus a `dependencies` catch-all. All scoped to minor/patch, so majors still open individual PRs. Group order is intentional — dependabot assigns each dependency to the first matching group, so the family carve-outs sit above the catch-all.
- **`open-pull-requests-limit: 10`** on all three ecosystems (was unset, defaulting to 5).
