### PR TITLE
feat: Add safe 1.5.0 missing abis

### DIFF
--- a/app/services/abis.py
+++ b/app/services/abis.py
@@ -13,6 +13,7 @@ from safe_eth.eth.contracts import (
     get_safe_V1_1_1_contract,
     get_safe_V1_3_0_contract,
     get_safe_V1_4_1_contract,
+    get_safe_V1_5_0_contract,
     get_uniswap_exchange_contract,
 )
 from web3 import Web3
@@ -104,6 +105,7 @@ class AbiService:
             get_safe_V1_1_1_contract(self.dummy_w3).abi,
             get_safe_V1_3_0_contract(self.dummy_w3).abi,
             get_safe_V1_4_1_contract(self.dummy_w3).abi,
+            get_safe_V1_5_0_contract(self.dummy_w3).abi,
         ]
 
     def get_safe_abis(self) -> list[ABI]:

--- a/app/tests/services/test_abis.py
+++ b/app/tests/services/test_abis.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 from collections import Counter
 
 from ...datasources.db.database import db_session_context
@@ -19,18 +20,18 @@ class TestAbiService(AsyncDbTestCase):
         await self.abi_service.load_local_abis_in_database()
         self.assertEqual(len(await AbiSource.get_all()), 1)
         abis = await Abi.get_all()
-        self.assertEqual(len(abis), 153)
+        self.assertEqual(len(abis), 154)
         relevance_counts = Counter(abi.relevance for abi in abis)
-        self.assertEqual(relevance_counts[100], 5)
+        self.assertEqual(relevance_counts[100], 6)
         self.assertEqual(relevance_counts[90], 5)
         self.assertEqual(relevance_counts[50], 143)
 
         await self.abi_service.load_local_abis_in_database()
-        self.assertEqual(len(await Abi.get_all()), 153)
+        self.assertEqual(len(await Abi.get_all()), 154)
 
     def test_get_safe_contracts_abis(self):
         abis = self.abi_service.get_safe_contracts_abis()
-        self.assertEqual(len(abis), 5)
+        self.assertEqual(len(abis), 6)
 
     def test_get_safe_abis(self):
         abis = self.abi_service.get_safe_abis()


### PR DESCRIPTION
- Related with [WA-2922](https://linear.app/safe-global/issue/WA-2922/seed-150-contract-data-in-transaction-service-and-decoder-service-ops#comment-4899e0b3)


Adds missing ABIs and resolves [this](https://linear.app/safe-global/issue/WA-2922/seed-150-contract-data-in-transaction-service-and-decoder-service-ops#comment-aa8547bc) comment.
