### PR TITLE
fix: Fix worker class and proxy headers in the web entrypoint

### DIFF
--- a/docker/web/run_web.sh
+++ b/docker/web/run_web.sh
@@ -11,4 +11,9 @@ cp -r static/ $DOCKER_SHARED_DIR/
 echo "==> $(date +%H:%M:%S) ==> Running migrations..."
 alembic upgrade head
 echo "==> $(date +%H:%M:%S) ==> Running Gunicorn... "
-exec gunicorn -k uvicorn.workers.UvicornWorker -b unix:$DOCKER_SHARED_DIR/uvicorn.socket -b 0.0.0.0:8888 app.main:app
+exec gunicorn app.main:app \
+  -k uvicorn_worker.UvicornWorker \
+  -b unix:$DOCKER_SHARED_DIR/uvicorn.socket \
+  -b 0.0.0.0:8888 \
+  --workers "${WEB_CONCURRENCY:-1}" \
+  --forwarded-allow-ips "*"


### PR DESCRIPTION
Linear: PLA-1938

### What was wrong? 👾

Same three things as safe-global/safe-queue-service#260, which ships an identical entrypoint. Full analysis there.

1. `uvicorn.workers.UvicornWorker` has been deprecated since uvicorn 0.30 and the module is going away. `uvicorn-worker` was already a dependency in `pyproject.toml`, just unused. (The `DeprecationWarning` is filtered out by default, so this is about the removal, not log noise.)

2. `request.client` and the request scheme depended on how the request reached the app. Over a unix socket uvicorn leaves `scope["client"]` as `None`, so `ProxyHeadersMiddleware` never trusted the connection under the default `forwarded_allow_ips=127.0.0.1` and dropped both `X-Forwarded-For` and `X-Forwarded-Proto`. The same request over the TCP bind got them applied. Since nginx talks to the socket, everything coming through nginx lost the real client and scheme.

3. The worker count was invisible: it was `WEB_CONCURRENCY` or 1 through the gunicorn default.

`*` is the only value that works on a unix socket — the connection reports no peer address to match a trusted host against. Both binds are pod-local and the headers on either come from the nginx sidecar.

### How was it fixed? 🎯

```
exec gunicorn app.main:app \
  -k uvicorn_worker.UvicornWorker \
  -b unix:$DOCKER_SHARED_DIR/uvicorn.socket \
  -b 0.0.0.0:8888 \
  --workers "${WEB_CONCURRENCY:-1}" \
  --forwarded-allow-ips "*"
```

`${WEB_CONCURRENCY:-1}` keeps the current behaviour, just spelled out.

### Verification

Built the image and ran `web` + `nginx` from `docker-compose.yml`:

```
[INFO] Listening at: unix:/nginx/uvicorn.socket,http://0.0.0.0:8888 (1)
[INFO] Using worker: uvicorn_worker.UvicornWorker
```

`:8888` serves `/health` 200 and `/api/v1/about` → `1.16.1`. Through nginx on `:8000`: `/health`, `/`, `/static/favicon.ico` and `/api/v1/about` all 200.

Sending `X-Forwarded-Proto: https` straight to the unix socket from inside the container, the app now logs the request as `https://localhost/health`. It logged `http://` before.

### Out of scope

- Worker recycling (`max-requests`): no measured leak to justify it.
- The taskiq worker entrypoint.
- The `web` service in `docker-compose.yml` uses `env_file: .env`, whose hosts are `localhost`, so the container cannot reach `db`/`redis`/`rabbitmq`. `.env.docker` exists with the right hostnames and is what `safe-queue-service` uses. Worth a follow-up; I worked around it with a compose override to verify this PR.
