### PR TITLE
feat: Load contract ABIs outside the blocking startup path

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,8 @@ class Settings(BaseSettings):
     CONTRACT_MAX_DOWNLOAD_RETRIES: int = (
         90  # Task running once per day, means 3 months trying.
     )
+    DECODER_ABI_RELOAD_SECONDS: int = 30
+    DECODER_LOAD_RETRY_SECONDS: int = 10
     CONTRACT_LOGO_BASE_URL: str = (
         "https://safe-transaction-assets.safe.global/contracts/logos"
     )

--- a/app/main.py
+++ b/app/main.py
@@ -12,14 +12,47 @@ from starlette.responses import Response
 from app.loggers.safe_logger import HttpRequestLog, HttpResponseLog
 
 from . import VERSION
+from .config import settings
 from .datasources.queue.exceptions import QueueProviderUnableToConnectException
 from .datasources.queue.queue_provider import QueueProvider
 from .routers import about, admin, contracts, data_decoder, default
 from .services.abis import AbiService
-from .services.data_decoder import get_data_decoder_service
+from .services.data_decoder import (
+    get_data_decoder_service,
+    set_data_decoder_ready,
+)
 from .services.events import EventsService
 
 logger = logging.getLogger()
+
+
+async def _load_data_decoder(abi_service: AbiService) -> None:
+    """
+    Load the ABIs into the decoder and publish readiness once done.
+
+    Retries forever because it runs outside the startup path: a database that is
+    slow or unreachable must delay readiness, not abort the process. The
+    `get_data_decoder_service` cache entry is dropped when its coroutine raises,
+    so every attempt starts from a clean service.
+
+    :param abi_service:
+    """
+    local_abis_loaded = False
+    while True:
+        try:
+            if not local_abis_loaded:
+                await abi_service.load_local_abis_in_database()
+                local_abis_loaded = True
+            await get_data_decoder_service()
+            set_data_decoder_ready(True)
+            logger.info("Data decoder is ready")
+            return
+        except Exception:
+            logger.exception(
+                "Cannot load contract ABIs, retrying in %d seconds",
+                settings.DECODER_LOAD_RETRY_SECONDS,
+            )
+            await asyncio.sleep(settings.DECODER_LOAD_RETRY_SECONDS)
 
 
 @asynccontextmanager
@@ -28,14 +61,17 @@ async def lifespan(app: FastAPI):
     Define the lifespan of the application:
     - At startup:
          - Connects to the QueueProvider.
-         - Load hardcoded ABIs in database
-         - Initializes DataDecoderService
+         - Starts loading the hardcoded ABIs and the DataDecoderService in the
+           background, so requests are accepted while it happens. Readiness is
+           published when it finishes.
     - At shutdown:
         - Disconnects from the QueueProvider.
     """
     queue_provider = QueueProvider()
     consume_task = None
     abi_service = AbiService()
+    load_decoder_task = asyncio.create_task(_load_data_decoder(abi_service))
+    logger.debug("Created task to load the contract ABIs for decoding")
     try:
         loop = asyncio.get_running_loop()
         try:
@@ -50,13 +86,10 @@ async def lifespan(app: FastAPI):
                 queue_provider.consume(events_service.process_event)
             )
             logger.debug("Created task to consume elements from Queue Provider")
-
-        # Load hardcoded ABIs in database
-        await abi_service.load_local_abis_in_database()
-        # Initializes DataDecoderService
-        await get_data_decoder_service()
         yield
     finally:
+        load_decoder_task.cancel()
+        set_data_decoder_ready(False)
         if consume_task:
             consume_task.cancel()
         await queue_provider.disconnect()

--- a/app/routers/data_decoder.py
+++ b/app/routers/data_decoder.py
@@ -1,14 +1,19 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 from typing import cast
 
 from eth_typing import Address
 from fastapi import APIRouter, HTTPException
 
+from app.config import settings
 from app.routers.models import (
     DataDecodedPublic,
     DataDecoderInput,
     ParameterDecodedPublic,
 )
-from app.services.data_decoder import get_data_decoder_service
+from app.services.data_decoder import (
+    get_data_decoder_service,
+    is_data_decoder_ready,
+)
 
 router = APIRouter(
     prefix="/data-decoder",
@@ -32,6 +37,13 @@ async def data_decoder(input_data: DataDecoderInput) -> DataDecodedPublic:
     - *ONLY_FUNCTION_MATCH*: Matched function from another contract.
     - *NO_MATCH*: Selector cannot be decoded.
     """
+    if not is_data_decoder_ready():
+        raise HTTPException(
+            status_code=503,
+            detail="Contract ABIs are still being loaded",
+            headers={"Retry-After": str(settings.DECODER_LOAD_RETRY_SECONDS)},
+        )
+
     data_decoder_service = await get_data_decoder_service()
 
     # Load new ABIs from the database (runs before decoding to ensure fresh ABIs)

--- a/app/routers/default.py
+++ b/app/routers/default.py
@@ -49,7 +49,8 @@ async def health_ready() -> JSONResponse:
 
     Decoding is served from an in-memory selector map built at startup, so the
     service is ready only once that map is loaded. The database is not part of
-    the check: selector-only decoding keeps working while it is unreachable.
+    the check: while it is unreachable the service keeps decoding from that map
+    and reports a lower accuracy, instead of failing the request.
     """
     decoder_ready = is_data_decoder_ready()
     return JSONResponse(

--- a/app/routers/default.py
+++ b/app/routers/default.py
@@ -1,9 +1,12 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 from typing import Literal
 
 from fastapi import APIRouter
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from starlette.requests import Request
+
+from app.services.data_decoder import is_data_decoder_ready
 
 router = APIRouter()
 
@@ -34,5 +37,22 @@ async def redoc_html(req: Request):
 
 
 @router.get("/health", include_in_schema=False)
+@router.get("/health/live", include_in_schema=False)
 async def health() -> Literal["OK"]:
     return "OK"
+
+
+@router.get("/health/ready", include_in_schema=False)
+async def health_ready() -> JSONResponse:
+    """
+    Readiness probe.
+
+    Decoding is served from an in-memory selector map built at startup, so the
+    service is ready only once that map is loaded. The database is not part of
+    the check: selector-only decoding keeps working while it is unreachable.
+    """
+    decoder_ready = is_data_decoder_ready()
+    return JSONResponse(
+        content={"ready": decoder_ready},
+        status_code=200 if decoder_ready else 503,
+    )

--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -15,6 +15,7 @@ from safe_eth.eth.contracts import get_multi_send_contract
 from safe_eth.eth.utils import fast_to_checksum_address
 from safe_eth.safe.multi_send import MultiSend
 from safe_eth.util.util import to_0x_hex_str
+from sqlalchemy.exc import SQLAlchemyError
 from web3 import Web3
 from web3._utils.abi import get_abi_input_names, get_abi_input_types, map_abi_data
 from web3._utils.normalizers import implicitly_identity
@@ -184,6 +185,8 @@ class DataDecoderService:
         :param abi: ABI
         :return: Dictionary with function selector as bytes and the ContractFunction
         """
+        if not any(fn_abi["type"] == "function" for fn_abi in abi):
+            return {}
         return await asyncio.to_thread(selectors_from_abis, [abi])
 
     async def _generate_selectors_with_abis_from_abis(
@@ -262,11 +265,21 @@ class DataDecoderService:
         if selector in self.fn_selectors_with_abis:
             # Try to use specific ABI if address provided
             if address:
-                contract_selectors_with_abis = (
-                    await self.get_contract_abi_selectors_with_functions(
-                        address, chain_id
+                try:
+                    contract_selectors_with_abis = (
+                        await self.get_contract_abi_selectors_with_functions(
+                            address, chain_id
+                        )
                     )
-                )
+                except SQLAlchemyError:
+                    # The selector map still decodes the function, so losing the
+                    # database lowers accuracy instead of failing the request
+                    logger.exception(
+                        "%s: Cannot read the ABI for %s",
+                        self.__class__.__name__,
+                        address,
+                    )
+                    contract_selectors_with_abis = None
                 if (
                     contract_selectors_with_abis
                     and selector in contract_selectors_with_abis
@@ -531,13 +544,22 @@ class DataDecoderService:
         if selector not in self.fn_selectors_with_abis:
             return DecodingAccuracyEnum.NO_MATCH
         if address is not None:
-            async with transactional_session_context():
-                if chain_id is not None and await self.get_contract_abi(
-                    address, chain_id=chain_id
-                ):
-                    return DecodingAccuracyEnum.FULL_MATCH
-                if await self.get_contract_abi(address, None):
-                    return DecodingAccuracyEnum.PARTIAL_MATCH
+            try:
+                async with transactional_session_context():
+                    if chain_id is not None and await self.get_contract_abi(
+                        address, chain_id=chain_id
+                    ):
+                        return DecodingAccuracyEnum.FULL_MATCH
+                    if await self.get_contract_abi(address, None):
+                        return DecodingAccuracyEnum.PARTIAL_MATCH
+            except SQLAlchemyError:
+                # Without the database the address cannot be matched, which is
+                # what ONLY_FUNCTION_MATCH already reports
+                logger.exception(
+                    "%s: Cannot read the ABI for %s",
+                    self.__class__.__name__,
+                    address,
+                )
         return DecodingAccuracyEnum.ONLY_FUNCTION_MATCH
 
     async def add_abi(self, abi: ABI) -> bool:

--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -589,10 +589,16 @@ class DataDecoderService:
         if loop.time() < self._next_reload_at:
             return 0
 
-        acquired = False
         try:
             await asyncio.wait_for(self.lock_load_new_abis.acquire(), timeout=0.01)
-            acquired = True
+        except TimeoutError:
+            logger.debug(
+                "%s: Reloading of ABIs in progress by another request, not doing anything",
+                self.__class__.__name__,
+            )
+            return 0
+
+        try:
             # Arm the next window while the lock is held, so requests arriving
             # during the reload skip it instead of waiting on the lock
             self._next_reload_at = loop.time() + settings.DECODER_ABI_RELOAD_SECONDS
@@ -630,15 +636,8 @@ class DataDecoderService:
                 loaded_abis,
             )
             return loaded_abis
-        except TimeoutError:
-            logger.debug(
-                "%s: Reloading of ABIs in progress by another request, not doing anything",
-                self.__class__.__name__,
-            )
-            return 0
         except Exception:
             logger.exception("%s: Cannot reload contract ABIs", self.__class__.__name__)
             return 0
         finally:
-            if acquired:
-                self.lock_load_new_abis.release()
+            self.lock_load_new_abis.release()

--- a/app/services/data_decoder.py
+++ b/app/services/data_decoder.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from enum import Enum
 from typing import Any, NotRequired, TypedDict, Union, cast
 
@@ -19,6 +19,7 @@ from web3 import Web3
 from web3._utils.abi import get_abi_input_names, get_abi_input_types, map_abi_data
 from web3._utils.normalizers import implicitly_identity
 
+from ..config import settings
 from ..datasources.db.database import transactional_session_context
 from ..datasources.db.models import Abi, Contract
 
@@ -73,6 +74,42 @@ async def get_data_decoder_service() -> "DataDecoderService":
     return data_decoder_service
 
 
+_data_decoder_ready = False
+
+
+def is_data_decoder_ready() -> bool:
+    """
+    :return: `True` when the ABIs are loaded and decoding is possible
+    """
+    return _data_decoder_ready
+
+
+def set_data_decoder_ready(ready: bool) -> None:
+    """
+    Publish whether the decoder can serve requests.
+
+    :param ready:
+    """
+    global _data_decoder_ready
+    _data_decoder_ready = ready
+
+
+def selectors_from_abis(abis: Sequence[ABI]) -> dict[bytes, ABIFunction]:
+    """
+    Build the 4byte selector map for a group of ABIs. CPU bound and blocking, so
+    callers run it in a thread, that's why it's outside of the module.
+
+    :param abis: ABIs to index. Later ABIs win a selector collision
+    :return: Dictionary with function selector as bytes and the function abi
+    """
+    return {
+        function_abi_to_4byte_selector(fn_abi): fn_abi
+        for abi in abis
+        for fn_abi in abi
+        if fn_abi["type"] == "function"
+    }
+
+
 @implicitly_identity
 def addresses_checksummed_normalizer(
     type_str: TypeStr, data: Any
@@ -92,12 +129,20 @@ def addresses_checksummed_normalizer(
 class DataDecoderService:
     EXEC_TRANSACTION_SELECTOR = HexBytes("0x6a761202")
 
+    # ABIs handed to a single thread hop when building the selector map
+    SELECTOR_BATCH_SIZE = 500
+
     dummy_w3 = Web3()
 
     fn_selectors_with_abis: dict[bytes, ABIFunction]
     multisend_abis: list[ABI]
     multisend_fn_selectors_with_abis: dict[bytes, ABIFunction]
     last_abi_id: int | None
+    lock_load_new_abis: asyncio.Lock
+
+    def __init__(self) -> None:
+        self.lock_load_new_abis = asyncio.Lock()
+        self._next_reload_at = 0.0
 
     async def init(self) -> None:
         """
@@ -122,16 +167,15 @@ class DataDecoderService:
             logger.info(
                 "%s: Contract ABIs for decoding were loaded", self.__class__.__name__
             )
-            self.multisend_abis: list[ABI] = [
-                m async for m in self.get_multisend_abis()
-            ]
-            self.multisend_fn_selectors_with_abis: dict[bytes, ABIFunction] = {}
-            for abi in self.multisend_abis:
-                self.multisend_fn_selectors_with_abis.update(
-                    await self._generate_selectors_with_abis_from_abi(abi)
-                )
-        # lock_load_new_abis will avoid concurrent calls to load_new_abis
-        self.lock_load_new_abis = asyncio.Lock()
+        self.multisend_abis: list[ABI] = [m async for m in self.get_multisend_abis()]
+        self.multisend_fn_selectors_with_abis: dict[bytes, ABIFunction] = (
+            selectors_from_abis(self.multisend_abis)
+        )
+        # Everything up to `last_abi_id` is loaded, so the next reload is only
+        # due once the interval has passed
+        self._next_reload_at = (
+            asyncio.get_running_loop().time() + settings.DECODER_ABI_RELOAD_SECONDS
+        )
 
     async def _generate_selectors_with_abis_from_abi(
         self, abi: ABI
@@ -140,17 +184,7 @@ class DataDecoderService:
         :param abi: ABI
         :return: Dictionary with function selector as bytes and the ContractFunction
         """
-        fn_abis = [fn_abi for fn_abi in abi if fn_abi["type"] == "function"]
-        if not fn_abis:
-            return {}
-
-        # Process all selectors in a single thread to avoid thread creation overhead
-        def generate_selectors():
-            return {
-                function_abi_to_4byte_selector(fn_abi): fn_abi for fn_abi in fn_abis
-            }
-
-        return await asyncio.to_thread(generate_selectors)
+        return await asyncio.to_thread(selectors_from_abis, [abi])
 
     async def _generate_selectors_with_abis_from_abis(
         self, abis: AsyncIterator[ABI]
@@ -160,13 +194,17 @@ class DataDecoderService:
         selector
         :return: Dictionary with function selector as bytes and the function abi
         """
-        return {
-            fn_selector: fn_abi
-            async for supported_abi in abis
-            for fn_selector, fn_abi in (
-                await self._generate_selectors_with_abis_from_abi(supported_abi)
-            ).items()
-        }
+        # Optimization: Use one thread for a `SELECTOR_BATCH_SIZE` of ABIs
+        selectors: dict[bytes, ABIFunction] = {}
+        batch: list[ABI] = []
+        async for supported_abi in abis:
+            batch.append(supported_abi)
+            if len(batch) >= self.SELECTOR_BATCH_SIZE:
+                selectors.update(await asyncio.to_thread(selectors_from_abis, batch))
+                batch = []
+        if batch:
+            selectors.update(await asyncio.to_thread(selectors_from_abis, batch))
+        return selectors
 
     async def get_supported_abis(self) -> AsyncIterator[ABI]:
         """
@@ -523,12 +561,19 @@ class DataDecoderService:
         Uses a monotonic `id` cursor (``last_abi_id``) so that ABIs inserted
         with identical timestamps are never skipped.
 
-        :return: Number of new ABIs loaded
+        :return: Number of new ABIs loaded, 0 when the reload was skipped or failed
         """
+        loop = asyncio.get_running_loop()
+        if loop.time() < self._next_reload_at:
+            return 0
+
         acquired = False
         try:
             await asyncio.wait_for(self.lock_load_new_abis.acquire(), timeout=0.01)
             acquired = True
+            # Arm the next window while the lock is held, so requests arriving
+            # during the reload skip it instead of waiting on the lock
+            self._next_reload_at = loop.time() + settings.DECODER_ABI_RELOAD_SECONDS
             logger.debug(
                 "%s: Reloading contract ABIs",
                 self.__class__.__name__,
@@ -568,6 +613,9 @@ class DataDecoderService:
                 "%s: Reloading of ABIs in progress by another request, not doing anything",
                 self.__class__.__name__,
             )
+            return 0
+        except Exception:
+            logger.exception("%s: Cannot reload contract ABIs", self.__class__.__name__)
             return 0
         finally:
             if acquired:

--- a/app/tests/routers/test_data_decoder.py
+++ b/app/tests/routers/test_data_decoder.py
@@ -9,12 +9,17 @@ from safe_eth.eth.utils import get_empty_tx_params
 from safe_eth.util.util import to_0x_hex_str
 from web3 import Web3
 
+from ...config import settings
 from ...datasources.abis.gnosis_protocol import cowswap_settlement_v2_abi
 from ...datasources.db.database import db_session_context, transactional_session_context
 from ...datasources.db.models import Abi, AbiSource, Contract
 from ...main import app
 from ...services.abis import AbiService
-from ...services.data_decoder import DecodingAccuracyEnum, get_data_decoder_service
+from ...services.data_decoder import (
+    DecodingAccuracyEnum,
+    get_data_decoder_service,
+    set_data_decoder_ready,
+)
 from ..datasources.db.async_db_test_case import AsyncDbTestCase
 from ..services.mocks_data_decoder import example_abi, example_swapped_abi
 
@@ -33,9 +38,25 @@ class TestRouterAbout(AsyncDbTestCase):
 
     def setUp(self):
         get_data_decoder_service.cache_clear()
+        # Readiness is published by the lifespan, which does not run under
+        # `ASGITransport`
+        set_data_decoder_ready(True)
 
     def tearDown(self):
         get_data_decoder_service.cache_clear()
+        set_data_decoder_ready(False)
+
+    async def test_view_data_decoder_not_ready(self):
+        set_data_decoder_ready(False)
+
+        response = await self.client.post(
+            "/api/v1/data-decoder", json={"data": "0x12345678"}
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response.headers["retry-after"], str(settings.DECODER_LOAD_RETRY_SECONDS)
+        )
 
     @db_session_context
     async def test_view_data_decoder(self):

--- a/app/tests/routers/test_default.py
+++ b/app/tests/routers/test_default.py
@@ -1,8 +1,10 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import unittest
 
 from fastapi.testclient import TestClient
 
 from ...main import app
+from ...services.data_decoder import set_data_decoder_ready
 
 
 class TestRouterDefault(unittest.TestCase):
@@ -30,6 +32,24 @@ class TestRouterDefault(unittest.TestCase):
         response = self.client.get("/health")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), "OK")
+
+    def test_view_health_live(self):
+        response = self.client.get("/health/live")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), "OK")
+
+    def test_view_health_ready(self):
+        self.addCleanup(set_data_decoder_ready, False)
+
+        set_data_decoder_ready(False)
+        response = self.client.get("/health/ready")
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json(), {"ready": False})
+
+        set_data_decoder_ready(True)
+        response = self.client.get("/health/ready")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"ready": True})
 
     def test_redirect_middleware(self):
         """Test that redirects work correctly with or without proxy headers (x-forwarded-prefix and x-forwarded-host)"""

--- a/app/tests/services/test_data_decoder.py
+++ b/app/tests/services/test_data_decoder.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: FSL-1.1-MIT
+from unittest.mock import patch
+
 from eth_typing import Address
 from hexbytes import HexBytes
 from safe_eth.eth.constants import NULL_ADDRESS
@@ -20,6 +22,7 @@ from app.datasources.abis.gnosis_protocol import (
     gnosis_protocol_abi,
 )
 
+from ...config import settings
 from ...datasources.db.database import db_session_context
 from ...datasources.db.models import Abi, AbiSource, Contract
 from ...services.data_decoder import (
@@ -568,6 +571,7 @@ class TestDataDecoderService(AsyncDbTestCase):
             },
         )
 
+    @patch.object(settings, "DECODER_ABI_RELOAD_SECONDS", 0)
     @db_session_context
     async def test_load_new_abis(self):
         decoder_service = DataDecoderService()

--- a/app/tests/services/test_data_decoder.py
+++ b/app/tests/services/test_data_decoder.py
@@ -13,6 +13,7 @@ from safe_eth.eth.contracts import (
 from safe_eth.eth.utils import fast_keccak_text, get_empty_tx_params
 from safe_eth.safe.multi_send import MultiSendOperation
 from safe_eth.util.util import to_0x_hex_str
+from sqlalchemy.exc import OperationalError
 from web3 import Web3
 
 from app.datasources.abis.compound import comptroller_abi, ctoken_abi
@@ -570,6 +571,28 @@ class TestDataDecoderService(AsyncDbTestCase):
                 )
             },
         )
+
+    @db_session_context
+    async def test_decoding_degrades_when_the_database_is_unreachable(self):
+        await self._store_safe_contract_abi()
+        decoder_service = DataDecoderService()
+        await decoder_service.init()
+
+        with patch.object(
+            Contract,
+            "get_abi_by_contract_address",
+            side_effect=OperationalError("SELECT", {}, Exception("connection refused")),
+        ):
+            fn_name, arguments = await decoder_service.decode_transaction(
+                HexBytes(exec_transaction_data_mock), address=Address(b"a"), chain_id=1
+            )
+            accuracy = await decoder_service.get_decoding_accuracy(
+                HexBytes(exec_transaction_data_mock), address=Address(b"a"), chain_id=1
+            )
+
+        # The selector map is in memory, so the function still decodes
+        self.assertEqual(fn_name, "execTransaction")
+        self.assertEqual(accuracy, DecodingAccuracyEnum.ONLY_FUNCTION_MATCH)
 
     @patch.object(settings, "DECODER_ABI_RELOAD_SECONDS", 0)
     @db_session_context

--- a/app/tests/services/test_data_decoder.py
+++ b/app/tests/services/test_data_decoder.py
@@ -594,6 +594,19 @@ class TestDataDecoderService(AsyncDbTestCase):
         self.assertEqual(fn_name, "execTransaction")
         self.assertEqual(accuracy, DecodingAccuracyEnum.ONLY_FUNCTION_MATCH)
 
+    @db_session_context
+    async def test_load_new_abis_skipped_while_another_reload_holds_the_lock(self):
+        decoder_service = DataDecoderService()
+        await decoder_service.init()
+        # Past the reload interval, so only the lock can stop it
+        decoder_service._next_reload_at = 0
+
+        await decoder_service.lock_load_new_abis.acquire()
+        try:
+            self.assertEqual(await decoder_service.load_new_abis(), 0)
+        finally:
+            decoder_service.lock_load_new_abis.release()
+
     @patch.object(settings, "DECODER_ABI_RELOAD_SECONDS", 0)
     @db_session_context
     async def test_load_new_abis(self):


### PR DESCRIPTION
Closes PLA-1953

## Why

The web app loaded every contract ABI inside the FastAPI `lifespan`, before `yield`. Any exception or slowness there leaves `server.started` as `False`, so the uvicorn worker exits with `WORKER_BOOT_ERROR`, the gunicorn master raises `HaltServer("Worker failed to boot.")` and the container dies. While the condition lasts it does not recover.

Two of the three startup steps talk to the database, so today every pod restart needs a healthy and fast database or the container dies permanently. That is the failure mode behind the 9 Sep outage, and crash loops in this deployment go back to 28 Aug.

## What changed

- The ABI load runs in a background task that retries, and readiness is published when it finishes.
- `/health` stays as liveness, `/health/live` is an alias matching the naming the other Safe services use, and `/health/ready` is new: 503 until the ABIs are loaded, 200 afterwards.
- The decode endpoint answers 503 with `Retry-After` while the ABIs are not loaded, instead of blocking on the in-flight load.
- A failed ABI reload no longer fails a decode request, so decoding keeps working from the selectors already in memory while the database is unreachable.
- The selector map is built with one thread hop per batch instead of one per ABI.
- `load_new_abis` no longer runs on every decode request. It is throttled to `DECODER_ABI_RELOAD_SECONDS`, so a decode request no longer opens a database transaction or waits up to 10ms on a lock.

## Numbers

Local benchmark, 100k rows in `abi`, same database and same venv:

| | `init()` |
| --- | --- |
| before | 14.4s |
| after | 1.9s |

The whole win is the thread batching. Raising the streaming row buffer with `yield_per` was tried and dropped: no measurable difference, and it only raises peak memory.

## Verified

- 90 tests pass.
- Started the app with Postgres stopped: the process stays up, `/health` answers 200, `/health/ready` answers 503, the load retries every 10s, and the service becomes ready about 10s after Postgres comes back, with the same PID and no restart. On `main` this scenario kills the container and it never recovers.

## Needs to land with an infra change

Infra PR: safe-global/legacy-safe-argocd-mgmt#605 (draft).

The only probe in production is a readiness probe on the nginx sidecar pointing at `/health`. It must be repointed at `/health/ready` before or together with this PR, otherwise pods report Ready while the selector map is still empty, which is worse than the current behaviour.

Worth doing in the same infra PR: `WEB_CONCURRENCY=1`. Two gunicorn workers each build their own copy of the selector map, which doubles memory and lets the probe answer from a worker that is ready while its sibling is not.

## Follow-ups

- PLA-1954: the ABI reload cursor advances before the rows are applied, so a failed reload skips them for the life of the process. Pre-existing.
- Selectors in an indexed table instead of in process memory. It is the only change that stops startup cost and memory growing with the `abi` table.
- Keyset pagination for the ABI load, and then revert the production idle-in-transaction timeout to the application default.
- https://github.com/safe-global/legacy-safe-argocd-mgmt/pull/605
